### PR TITLE
Add autorestarter localization

### DIFF
--- a/autorestarter/languages/english.lua
+++ b/autorestarter/languages/english.lua
@@ -1,0 +1,4 @@
+NAME = "English"
+LANGUAGE = {
+    restartCountdown = "Server Restarting in: %02d:%02d",
+}

--- a/autorestarter/libraries/client.lua
+++ b/autorestarter/libraries/client.lua
@@ -6,6 +6,6 @@ function MODULE:HUDPaint()
     if remaining > 0 and remaining <= interval * 0.25 then
         local m = math.floor(remaining / 60)
         local s = remaining % 60
-        draw.SimpleTextOutlined(string.format("Server Restarting in: %02d:%02d", m, s), lia.config.get("RestartCountdownFont"), ScrW() - 10, 10, Color(255, 255, 255), TEXT_ALIGN_RIGHT, TEXT_ALIGN_TOP, 1, Color(0, 0, 0))
+        draw.SimpleTextOutlined(L("restartCountdown", m, s), lia.config.get("RestartCountdownFont"), ScrW() - 10, 10, Color(255, 255, 255), TEXT_ALIGN_RIGHT, TEXT_ALIGN_TOP, 1, Color(0, 0, 0))
     end
 end


### PR DESCRIPTION
## Summary
- add English localization file for autorestarter
- use `L()` for restart countdown text

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b926401648327b1198fce884206d8