### PR TITLE
Add AdminStick support for player commands

### DIFF
--- a/bodygrouper/commands.lua
+++ b/bodygrouper/commands.lua
@@ -3,6 +3,7 @@
     privilege = "Manage Bodygroups",
     syntax = "[player Target Player]",
     desc = L("viewBodygroupsDesc"),
+    AdminStick = {},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1] or "")
         if not target or not IsValid(target) then

--- a/captions/commands.lua
+++ b/captions/commands.lua
@@ -2,6 +2,7 @@
     adminOnly = true,
     syntax = "[player Target Player] [string Caption] [number Duration]",
     desc = L("sendCaptionDesc"),
+    AdminStick = {},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local text = arguments[2]

--- a/cutscenes/commands.lua
+++ b/cutscenes/commands.lua
@@ -4,6 +4,7 @@ lia.command.add("cutscene", {
     privilege = "Use Cutscenes",
     syntax = "[player Target?]",
     desc = L("cutsceneCommandDesc"),
+    AdminStick = {},
     onRun = function(ply, args)
         local target
         if args[1] then

--- a/donator/commands.lua
+++ b/donator/commands.lua
@@ -3,6 +3,7 @@
     superAdminOnly = true,
     syntax = "[player Target Player]",
     desc = L("subtractCharSlotsDesc"),
+    AdminStick = {},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -19,6 +20,7 @@ lia.command.add("addcharslots", {
     superAdminOnly = true,
     syntax = "[player Target Player]",
     desc = L("addCharSlotsDesc"),
+    AdminStick = {},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         if not target or not IsValid(target) then
@@ -35,6 +37,7 @@ lia.command.add("setcharslots", {
     superAdminOnly = true,
     syntax = "[player Target Player] [number Slot Count]",
     desc = L("setCharSlotsDesc"),
+    AdminStick = {},
     onRun = function(client, arguments)
         local target = lia.util.findPlayer(client, arguments[1])
         local count = tonumber(arguments[2])

--- a/gamemasterpoints/commands.lua
+++ b/gamemasterpoints/commands.lua
@@ -36,6 +36,7 @@ lia.command.add("gmtpmoveto", {
     adminOnly = true,
     privilege = "Manage Gamemaster Teleport Points",
     desc = L("moveToPoint"),
+    AdminStick = {},
     syntax = "[player Target] [string Name]",
     onRun = function(client, arguments)
         local target, name

--- a/loyalism/commands.lua
+++ b/loyalism/commands.lua
@@ -4,6 +4,7 @@ lia.command.add("partytier", {
     privilege = "Management - Assign Party Tiers",
     syntax = "[player Target Player] [number Tier]",
     desc = L("partytierCommandDesc"),
+    AdminStick = {},
     onRun = function(client, arguments)
         local char = client:getChar()
         if not char then return L("mustBeOnCharacter") end

--- a/warrants/commands.lua
+++ b/warrants/commands.lua
@@ -2,6 +2,7 @@
     adminOnly = false,
     syntax = "[player Target Player]",
     desc = L("warrantCommandDesc"),
+    AdminStick = {},
     onRun = function(client, arguments)
         local character = client:getChar()
         local target = lia.util.findPlayer(client, arguments[1])

--- a/weightinv/commands.lua
+++ b/weightinv/commands.lua
@@ -2,6 +2,7 @@ lia.command.add("updateinvsize", {
     adminOnly = true,
     privilege = "Set Inventory Weight",
     desc = L("updateInventoryWeightDesc"),
+    AdminStick = {},
     syntax = "[player Target Player]",
     onRun = function(client, args)
         local target = lia.util.findPlayer(client, args[1])
@@ -39,6 +40,7 @@ lia.command.add("setinventorysize", {
     adminOnly = true,
     privilege = "Set Inventory Weight",
     desc = L("setInventoryWeightDesc"),
+    AdminStick = {},
     syntax = "[player Target Player] [number Max Weight]",
     onRun = function(client, args)
         local target = lia.util.findPlayer(client, args[1])


### PR DESCRIPTION
## Summary
- expose player-target commands in AdminStick by adding `AdminStick = {}`

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2f69888c8327a863b22e9c095060