### PR TITLE
Update README with docs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Browse all maintained modules on the [Lilia Modules site](https://liliaframework
 
 ---
 
+## 📚 Documentation
+
+Full usage instructions for every addon can be found on the [Lilia Modules site](https://liliaframework.github.io/Modules/).
+
+---
+
 ## ⚙️ Configuration
 
 ### Modules with a `config.lua`


### PR DESCRIPTION
## Summary
- add a Documentation section to README to mirror the format of the main Lilia repo

## Testing
- `node docsparser.js`

------
https://chatgpt.com/codex/tasks/task_e_68679fc9a2208327af305461bf373c53