### PR TITLE
Fix MODULE variable ordering

### DIFF
--- a/cutscenes/module.lua
+++ b/cutscenes/module.lua
@@ -3,4 +3,5 @@ MODULE.name = "Simple Cutscenes"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = "1.0.1"
-MODULE.desc = "A system for simple cutscenes"MODULE.Public = true
+MODULE.desc = "A system for simple cutscenes"
+MODULE.Public = true

--- a/gamemasterpoints/module.lua
+++ b/gamemasterpoints/module.lua
@@ -1,6 +1,7 @@
 MODULE.name = "Gamemaster Teleport Points"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.1"MODULE.desc = "Allow GMs to teleport to predefined points on the map"
+MODULE.version = "1.0.1"
+MODULE.desc = "Allow GMs to teleport to predefined points on the map"
 
 MODULE.Public = true

--- a/tying/submodules/tyingsearch/module.lua
+++ b/tying/submodules/tyingsearch/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Search Tying Sub-Module"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.1"MODULE.desc = "Adds Searching to Tying"
+MODULE.version = "1.0.1"
+MODULE.desc = "Adds Searching to Tying"


### PR DESCRIPTION
## Summary
- fix variable order in `cutscenes/module.lua`
- fix variable order in `gamemasterpoints/module.lua`
- fix variable order in `tying/submodules/tyingsearch/module.lua`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686dbf58233c8327938aeefddac35c42