### PR TITLE
Fix modules.md generation in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - run: cp modules.json docs/modules.md
       - uses: actions/download-artifact@v4
         with:
           name: module-zips


### PR DESCRIPTION
## Summary
- copy `modules.json` into `docs/modules.md` during gh-pages deployment so main's module listing publishes correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870a43f1fc88327a13853878e4d8e89