### PR TITLE
Fix download button generation

### DIFF
--- a/scrap_modules.js
+++ b/scrap_modules.js
@@ -34,7 +34,16 @@ for (const module of modulesList) {
     output += '\n';
   }
   if (download) {
-    output += `<p align="center"><strong>Download:</strong> <a href="${download}">${download}</a></p>\n\n`;
+    const buttonStyle = [
+      'display:inline-block',
+      'background-color:#25746c',
+      'color:#fff',
+      'padding:10px 20px',
+      'border-radius:6px',
+      'text-decoration:none',
+      'font-weight:bold'
+    ].join(';');
+    output += `<p align="center"><a href="${download}" style="${buttonStyle}">Download Here</a></p>\n\n`;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak `scrap_modules.js` to render a centered **Download Here** button

## Testing
- `node scrap_modules.js` *(fails: modules_data.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e331917c8327b7f8f0b62797c435