### PR TITLE
Fix link generation in module summary

### DIFF
--- a/scrap_modules.js
+++ b/scrap_modules.js
@@ -34,16 +34,7 @@ for (const module of modulesList) {
     output += '\n';
   }
   if (download) {
-    const buttonStyle = [
-      'display:inline-block',
-      'background-color:#25746c',
-      'color:#fff',
-      'padding:10px 20px',
-      'border-radius:6px',
-      'text-decoration:none',
-      'font-weight:bold'
-    ].join(';');
-    output += `<p align="center"><a href="${download}" style="${buttonStyle}">Download Here</a></p>\n\n`;
+    output += `<p align="center">[Download Here](${download})</p>\n\n`;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure scrap_modules.js outputs a clickable download link

## Testing
- `node scrap_modules.js` *(fails: modules_data.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719bbfecb08327be57cc60ec45eda0