### PR TITLE
Center markdown module titles

### DIFF
--- a/scrap_modules.js
+++ b/scrap_modules.js
@@ -26,7 +26,7 @@ let output = '# Optional Modules\n\n';
 
 for (const module of modulesList) {
   const { name = '', description = '', features = [], download = '' } = module;
-  output += `## ${name}\n\n`;
+  output += `<h2 align="center">${name}</h2>\n\n`;
   if (description) output += `**Description:** ${description}\n\n`;
   if (features.length) {
     output += '**Features:**\n';


### PR DESCRIPTION
## Summary
- make scrap_modules.js center module titles in generated markdown

## Testing
- `node scrap_modules.js` *(fails: modules_data.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871bb452f908327b19b4797a2fff21d