### PR TITLE
Update module distribution workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,15 @@ jobs:
           fi
       - run: mv modules_data.json modules.json
       - run: |
-          git checkout -B gh-pages
-          git add -f modules.json
+          git clone https://x-access-token:${{ secrets.LiliaGitSecret }}@github.com/LiliaFramework/LiliaFramework.github.io.git website
+          cp modules.json website/modules.json
+          cd website
+          git config user.email "githubactions@github.com"
+          git config user.name "GitHub Actions"
+          git add modules.json
           if ! git diff --cached --quiet; then
             git commit -m "Update modules.json with source URLs"
-            git push -f https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git gh-pages
+            git push https://x-access-token:${{ secrets.LiliaGitSecret }}@github.com/LiliaFramework/LiliaFramework.github.io.git HEAD:main
           fi
       - uses: actions/upload-artifact@v4
         with:
@@ -140,15 +144,10 @@ jobs:
         with:
           fetch-depth: 0
       - run: mkdir -p 'documentation'
-      - run: rm -f 'documentation/modules.md'
       - uses: actions/download-artifact@v4
         with:
           name: module-zips
           path: 'documentation/Downloads'
-      - uses: actions/download-artifact@v4
-        with:
-          name: modules-json
-          path: .
       - run: |
           for zip in 'documentation/Downloads'/*.zip; do
             folder=$(basename "$zip" .zip)
@@ -157,7 +156,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: cp modules.json 'documentation/modules.json'
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.LiliaGitSecret }}


### PR DESCRIPTION
## Summary
- update CI to send modules.json to `LiliaFramework/LiliaFramework.github.io`
- keep `modules.md` when building documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871fc66c5048327bc5e234259a7e644