### PR TITLE
Update modules to numeric version scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
             author=$(grep -Po 'MODULE\.author\s*=\s*"[^"]*"' "$module" | sed -E 's/.*=\s*"([^"]+)".*/\1/')
             discord=$(grep -Po 'MODULE\.discord\s*=\s*"[^"]*"' "$module" | sed -E 's/.*=\s*"([^"]+)".*/\1/')
             desc=$(grep -Po 'MODULE\.desc\s*=\s*"[^"]*"' "$module" | sed -E 's/.*=\s*"([^"]+)".*/\1/')
-            version=$(grep -Po 'MODULE\.version\s*=\s*"[^"]*"' "$module" | sed -E 's/.*=\s*"([^"]+)".*/\1/' || echo "1.0")
+            version=$(grep -Po 'MODULE\.version\s*=\s*([0-9]+)' "$module" | sed -E 's/.*=\s*([0-9]+)/\1/' || echo "10000")
             raw_features=$(grep -Po 'MODULE\.Features\s*=\s*(\{[^}]*\}|"[^"]*")' "$module" | head -n1 | sed -E 's/MODULE\.Features\s*=\s*//')
             if [ -n "$raw_features" ]; then
               if [[ $raw_features == \{* ]]; then

--- a/advert/module.lua
+++ b/advert/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Advert"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Provides a paid /advert command so players can broadcast server-wide messages with a built-in cooldown."
 MODULE.Public = true
 MODULE.Features = {"Adds a paid /advert command players can use", "Adds a cooldown via AdvertCooldown to limit spam", "Adds colored broadcast messages across the server", "Adds price control via AdvertPrice configuration", "Adds notifications when players lack funds",}

--- a/alcoholism/module.lua
+++ b/alcoholism/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Alcoholism"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Introduces drinkable alcohol items that raise intoxication levels and temporarily blur the player's vision and movement."
 MODULE.Public = true
 MODULE.Features = {"Adds alcohol items that raise BAC and gradually wear off", "Adds screen blur and movement effects that scale with intoxication", "Adds player notification when reaching DrunkNotifyThreshold", "Adds configurable BAC settings like AlcoholTickTime", "Adds multiple drink items with varying strength",}

--- a/autorestarter/module.lua
+++ b/autorestarter/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Auto Restarter"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Schedules periodic server restarts and displays a countdown so players know when the restart will occur."
 MODULE.Public = true
 MODULE.Features = {"Adds scheduling for automatic restarts using RestartInterval", "Adds a countdown overlay configurable via RestartCountdownFont", "Adds syncing of next restart time to clients", "Adds automatic changelevel when the timer expires", "Adds network messages to sync the restart countdown",}

--- a/bodygrouper/module.lua
+++ b/bodygrouper/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Bodygrouper"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.10"
+MODULE.version = 10010
 MODULE.desc = "Adds a customizable bodygroup closet entity that lets players adjust their model bodygroups through a menu."
 MODULE.Public = true
 lia.config.add("BodyGrouperModel", "Body Grouper Model", "models/props_c17/FurnitureDresser001a.mdl", nil, {

--- a/broadcasts/module.lua
+++ b/broadcasts/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Broadcasts"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.6"
+MODULE.version = 10006
 MODULE.desc = "Enables faction and class broadcast commands so staff can send messages to specific groups."
 MODULE.CAMIPrivileges = {
     {

--- a/captions/module.lua
+++ b/captions/module.lua
@@ -2,7 +2,7 @@
 MODULE.name = "Captions"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.6"
+MODULE.version = 10006
 MODULE.desc = "Provides an API for timed on-screen captions, ideal for story prompts or tutorials."
 MODULE.Public = true
 MODULE.Features = {"Adds an API for timed on-screen captions", "Adds support for both client and server use", "Adds an easy way to deliver story prompts", "Adds commands to send captions to players", "Adds duration control for each caption",}

--- a/cards/module.lua
+++ b/cards/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Cards"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Introduces a full deck of playing cards so players can draw random cards for minigames."
 MODULE.Public = true
 MODULE.Features = {"Adds a full playing card deck", "Adds random draws that sync to all players", "Adds support for simple minigames", "Adds easy reshuffling of the deck", "Adds hooks so other modules can use cards",}

--- a/chatmessages/module.lua
+++ b/chatmessages/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Chat Messages"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Periodically sends automated advert messages to chat at a configurable interval."
 MODULE.Public = true
 lia.config.add("ChatMessagesInterval", "Chat Messages Interval", 300, nil, {

--- a/cigs/module.lua
+++ b/cigs/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Cigarettes"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Adds consumable cigarette items that produce smoke puffs while gradually burning down."
 MODULE.WorkshopContent = "3519851007"
 MODULE.Public = true

--- a/cinematictext/module.lua
+++ b/cinematictext/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Cinematic Text"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.9"
+MODULE.version = 10009
 MODULE.desc = "Displays stylish splash text with letterboxed bars for cinematic flair."
 MODULE.Public = true
 MODULE.Features = {"Adds displays of cinematic splash text overlays", "Adds screen darkening with letterbox bars", "Adds support for scripted scenes", "Adds timed fades for dramatic effect", "Adds customizable text fonts",}

--- a/climb/module.lua
+++ b/climb/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Climb"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Lets players climb up ledges using movement keys with custom animations."
 MODULE.Public = true
 MODULE.Features = {"Adds the ability to climb ledges using movement keys", "Adds custom climbing animations", "Adds integration with movement restrictions", "Adds stamina cost for repeated climbs", "Adds sound effects for grip and landing",}

--- a/codeutils/module.lua
+++ b/codeutils/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Code Utils"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.6"
+MODULE.version = 10006
 MODULE.desc = "Provides extra helper functions for lia.util used by other modules."
 MODULE.Public = true
 MODULE.Features = {"Adds extra helper functions in lia.util", "Adds simplified utilities for common scripting tasks", "Adds a central library used by other modules", "Adds utilities for networking data", "Adds shared constants for modules",}

--- a/communitycommands/module.lua
+++ b/communitycommands/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Community Commands"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.8"
+MODULE.version = 10008
 MODULE.desc = "Adds chat commands that open community links for quick access to resources."
 MODULE.Public = true
 MODULE.Features = {"Adds chat commands to open community links", "Adds easy sharing of workshop and docs", "Adds configurable commands via settings", "Adds localization for command names", "Adds the ability to add custom URLs",}

--- a/compass/module.lua
+++ b/compass/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Compass"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Displays a rotating HUD compass that can mark spotted locations or enemies."
 MODULE.WorkshopContent = "3519849524"
 MODULE.Public = true

--- a/corpseid/module.lua
+++ b/corpseid/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Corpse ID"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.8"
+MODULE.version = 10008
 MODULE.desc = "Allows players to identify corpses after a short delay, displaying details above the body."
 MODULE.Public = true
 lia.config.add("IdentificationTime", "Identification Time", 5, nil, {

--- a/cursor/module.lua
+++ b/cursor/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Cursor"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Adds a toggleable custom cursor for navigating menus more easily."
 MODULE.Public = true
 MODULE.Features = {"Adds a toggleable custom cursor for the UI", "Adds a purely client-side implementation", "Adds improved menu navigation", "Adds a hotkey to quickly show or hide the cursor", "Adds compatibility with other menu modules",}

--- a/cutscenes/module.lua
+++ b/cutscenes/module.lua
@@ -2,7 +2,7 @@
 MODULE.name = "Simple Cutscenes"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Provides a lightweight framework for defining and playing synchronized cutscenes."
 MODULE.Public = true
 MODULE.Features = {"Adds a framework for simple cutscene playback", "Adds scenes defined through tables", "Adds syncing of camera movement across clients", "Adds commands to trigger cutscenes", "Adds the ability for players to skip",}

--- a/damagenumbers/module.lua
+++ b/damagenumbers/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Damage Numbers"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Shows floating damage numbers above targets and yourself whenever damage is dealt."
 MODULE.Public = true
 MODULE.Features = {"Adds floating combat text when hitting targets", "Adds different colors for damage types", "Adds display of damage dealt and received", "Adds scaling text based on damage amount", "Adds client option to disable numbers",}

--- a/developmenthud/module.lua
+++ b/developmenthud/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Development HUD"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.7"
+MODULE.version = 10007
 MODULE.desc = "Provides a staff-only HUD overlay with additional development information."
 MODULE.CAMIPrivileges = {
     {

--- a/developmentserver/module.lua
+++ b/developmentserver/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Development Server"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Allows running special development-only functions when the server is in testing mode."
 MODULE.Public = true
 MODULE.Features = {"Adds a development server mode for testing", "Adds the ability to run special development functions", "Adds a toggle via configuration", "Adds an environment flag for dev commands", "Adds logging of executed dev actions",}

--- a/discordrelay/module.lua
+++ b/discordrelay/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Discord Relay"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Relays server logs to a Discord channel through configurable webhooks."
 MODULE.Public = true
 MODULE.Features = {"Adds relaying of server logs to Discord", "Adds webhook integration for connectivity", "Adds formatting of real-time updates", "Adds multiple webhook URLs per log type", "Adds filtering to control which logs are sent",}

--- a/donator/module.lua
+++ b/donator/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Donator"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.9"
+MODULE.version = 10009
 MODULE.desc = "Includes helper libraries for managing donor perks and displaying them on the scoreboard."
 MODULE.Public = true
 MODULE.Features = {"Adds libraries to manage donor perks", "Adds tracking for donor ranks and perks", "Adds integration with the scoreboard", "Adds configurable perks by tier", "Adds analytics on total donations",}

--- a/doorkick/module.lua
+++ b/doorkick/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Door Kick"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.6"
+MODULE.version = 10006
 MODULE.desc = "Lets players breach doors by kicking them open, with events logged for staff."
 MODULE.Public = true
 if SERVER then lia.log.addType("doorkick", function(client, door) return string.format("%s kicked open %s", client:Name(), tostring(door)) end, "Player") end

--- a/enhanceddeath/module.lua
+++ b/enhanceddeath/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Hospitals"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Respawns players at designated hospitals where they recover after death."
 MODULE.Public = true
 MODULE.Features = {"Adds respawning of players at hospitals", "Adds a medical recovery system", "Adds support for multiple hospital spawns", "Adds configurable respawn delays", "Adds integration with death logs",}

--- a/extendeddescriptions/module.lua
+++ b/extendeddescriptions/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Extended Descriptions"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.9"
+MODULE.version = 10009
 MODULE.desc = "Allows items to have lengthy, localized descriptions for richer roleplay."
 MODULE.Public = true
 MODULE.Features = {"Adds support for long item descriptions", "Adds localization for multiple languages", "Adds better RP text display", "Adds automatic line wrapping", "Adds fallback to short descriptions",}

--- a/firstpersoneffects/module.lua
+++ b/firstpersoneffects/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "First Person Effects"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Adds view sway and head bob to create a more immersive first-person perspective."
 MODULE.Public = true
 MODULE.Features = {"Adds head bob and view sway", "Adds camera motion synced to actions", "Adds a realistic first-person feel", "Adds adjustable intensity via config", "Adds compatibility with vehicle seats",}

--- a/flashlight/module.lua
+++ b/flashlight/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Flashlight"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Reworks the flashlight with dynamic lighting and adjustable brightness settings."
 MODULE.Public = true
 MODULE.Features = {"Adds a serious flashlight with dynamic light", "Adds darkening of surroundings when turned off", "Adds adjustable brightness", "Adds battery consumption over time", "Adds keybind toggle support",}

--- a/freelook/module.lua
+++ b/freelook/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Free Look"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.5"
+MODULE.version = 10005
 MODULE.desc = "Lets players look around independently from their movement direction, similar to Escape from Tarkov."
 MODULE.Public = true
 MODULE.Features = {"Adds the ability to look around without turning the body", "Adds a toggle key similar to EFT", "Adds movement direction preservation", "Adds adjustable sensitivity while freelooking", "Adds optional head tracking support",}

--- a/gamemasterpoints/module.lua
+++ b/gamemasterpoints/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Gamemaster Teleport Points"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Lets game masters create teleport points around the map and quickly jump between them."
 MODULE.Public = true
 MODULE.Features = {"Adds teleport points for game masters", "Adds quick navigation across large maps", "Adds saving of locations for reuse", "Adds a command to list saved points", "Adds sharing of points with other staff",}

--- a/hud_extras/module.lua
+++ b/hud_extras/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Extra HUD Elements"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.7"
+MODULE.version = 10007
 MODULE.desc = "Adds optional HUD elements, such as an FPS counter, that other modules can extend."
 MODULE.Public = true
 lia.config.add("FPSHudFont", "FPS HUD Font", "PoppinsMedium", function()

--- a/instakill/module.lua
+++ b/instakill/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Instant Killing"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Makes headshots instantly lethal with configurable multipliers per weapon."
 MODULE.Public = true
 MODULE.Features = {"Adds instant kill on headshots", "Adds lethality configurable per weapon", "Adds extra tension to combat", "Adds friendly fire protection options", "Adds integration with damage numbers",}

--- a/inventory/module.lua
+++ b/inventory/module.lua
@@ -1,7 +1,7 @@
 MODULE.name = "Weight Inv"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Implements a weight-based inventory that limits how much a character can carry."
 MODULE.Public = true
 MODULE.enabled = function()

--- a/inventory/submodules/storage/module.lua
+++ b/inventory/submodules/storage/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Storage"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.6"
+MODULE.version = 10006
 MODULE.desc = "Provides spawnable storage containers for the weight-based inventory system."
 MODULE.CAMIPrivileges = {
     {

--- a/inventory/submodules/vendor/module.lua
+++ b/inventory/submodules/vendor/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Vendors"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Creates NPC vendors with customizable inventories and starting money."
 MODULE.CAMIPrivileges = {
     {

--- a/joinleavemessages/module.lua
+++ b/joinleavemessages/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Join Leave Messages"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.5"
+MODULE.version = 10005
 MODULE.desc = "Broadcasts notifications when players connect or disconnect from the server."
 MODULE.Public = true
 MODULE.Features = {"Adds announcements when players join", "Adds notifications on disconnect", "Adds improved community awareness", "Adds relay of messages to Discord", "Adds per-player toggle to hide messages",}

--- a/loadmessages/module.lua
+++ b/loadmessages/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Load Messages"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Displays a custom message to players based on their faction the first time they load a character."
 MODULE.Public = true
 MODULE.Features = {"Adds faction-based load messages", "Adds execution when players first load a character", "Adds customizable message text", "Adds color-coded formatting options", "Adds per-faction enable toggles",}

--- a/loyalism/module.lua
+++ b/loyalism/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Loyalism"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.7"
+MODULE.version = 10007
 MODULE.desc = "Implements loyalty tiers that grant access to the /partytier command when flagged."
 MODULE.Public = true
 lia.flag.add("T", "Access to /partytier")

--- a/mapcleaner/module.lua
+++ b/mapcleaner/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Map Cleaner"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Periodically cleans the map of debris and props based on a configurable schedule."
 MODULE.Public = true
 MODULE.Features = {"Adds periodic cleaning of map debris", "Adds a configurable interval", "Adds reduced server lag", "Adds a whitelist for protected entities", "Adds manual cleanup commands",}

--- a/modelpay/module.lua
+++ b/modelpay/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Model Pay"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Pays characters wages based on the model they use, allowing custom pay scales."
 MODULE.Public = true
 MODULE.Features = {"Adds payment to characters based on model", "Adds custom wage definitions", "Adds integration into the economy", "Adds config to exclude certain models", "Adds logs of wages issued",}

--- a/modeltweaker/module.lua
+++ b/modeltweaker/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Model Tweaker"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.9"
+MODULE.version = 10009
 MODULE.desc = "Provides an entity that lets admins adjust prop models' scale and rotation."
 MODULE.Public = true
 MODULE.Features = {"Adds an entity to tweak prop models", "Adds adjustments for scale and rotation", "Adds easy UI controls", "Adds saving of tweaked props between restarts", "Adds undo support for recent tweaks",}

--- a/npcdrop/module.lua
+++ b/npcdrop/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "NPC Drops"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Makes certain NPCs drop specified items on death, encouraging looting."
 MODULE.DropTable = {
     ["npc_zombie"] = {

--- a/npcspawner/module.lua
+++ b/npcspawner/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "NPC Spawner"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.5"
+MODULE.version = 10005
 MODULE.desc = "Automatically spawns NPCs at designated points and lets admins force spawns."
 MODULE.Public = true
 if SERVER then lia.log.addType("npcspawn", function(client, spawner) return string.format("%s forced NPC spawn at %s", client:Name(), tostring(spawner)) end, "Player") end

--- a/permaremove/module.lua
+++ b/permaremove/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Perma Remove"
 MODULE.author = "Boz [Base Code] & Samael [Rewrite]"
 MODULE.discord = "bozdev"
-MODULE.version = "1.0.5"
+MODULE.version = 10005
 MODULE.desc = "Lets admins permanently delete map entities and logs each removal for review."
 MODULE.Public = true
 if SERVER then lia.log.addType("permaremove", function(client, entity) return string.format("%s permanently removed %s", client:Name(), tostring(entity)) end, "Player") end

--- a/radio/module.lua
+++ b/radio/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Radio"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.10"
+MODULE.version = 10010
 MODULE.desc = "Introduces a radio chat system with customizable fonts and models."
 MODULE.WorkshopContent = "3431349806"
 MODULE.Public = true

--- a/raisedweapons/module.lua
+++ b/raisedweapons/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Raised Weapons"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Automatically lowers weapons when sprinting and raises them again after a short delay."
 MODULE.Public = true
 lia.config.add("WeaponRaiseSpeed", "Weapon Raise Speed", 1, nil, {

--- a/realisticdamage/module.lua
+++ b/realisticdamage/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Realistic Damage"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Applies body part multipliers and other tweaks for more realistic combat damage."
 MODULE.Public = true
 MODULE.Features = {"Adds damage scaling by body part", "Adds custom multipliers for realism", "Adds adjustments to player damage output", "Adds bleeding effects on high damage", "Adds friendly fire scaling options",}

--- a/realisticview/module.lua
+++ b/realisticview/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Realistic View"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.5"
+MODULE.version = 10005
 MODULE.desc = "Replaces the camera with a full-body first-person view and smooth transition effects."
 MODULE.Public = true
 MODULE.Features = {"Adds a first-person view that shows the full body", "Adds immersive camera transitions", "Adds compatibility with animations", "Adds smooth leaning animations", "Adds optional third-person override",}

--- a/rumour/module.lua
+++ b/rumour/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Rumour"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Adds an anonymous rumour command so players can spread hearsay without revealing themselves."
 MODULE.Public = true
 MODULE.Features = {"Adds an anonymous rumour chat command", "Adds hiding of the sender's identity", "Adds encouragement for roleplay intrigue", "Adds a cooldown to prevent spam", "Adds admin logging of rumour messages",}

--- a/scrap_modules.js
+++ b/scrap_modules.js
@@ -27,6 +27,16 @@ if (fs.existsSync(definitionPath)) {
   console.warn(`${definitionPath} not found and no moduleDetails in JSON.`);
 }
 
+function toVersionString(version) {
+  if (typeof version === 'number') {
+    const major = Math.floor(version / 10000);
+    const minor = Math.floor(version / 100) % 100;
+    const patch = version % 100;
+    return `${major}.${minor}.${patch}`;
+  }
+  return version;
+}
+
 let output = '# Optional Modules\n\n';
 
 for (const module of modulesList) {
@@ -37,7 +47,8 @@ for (const module of modulesList) {
     features = [],
     download = '',
   } = module;
-  const versionLabel = version ? ` ${version}` : '';
+  const versionStr = toVersionString(version);
+  const versionLabel = versionStr ? ` ${versionStr}` : '';
   output += `<h2 align="center">${name}${versionLabel}</h2>\n\n`;
   if (description) output += `**Description:** ${description}\n\n`;
   if (features.length) {

--- a/shootlock/module.lua
+++ b/shootlock/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Shoot Locks"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Allows players to shoot door locks to force them open as a loud breach option."
 MODULE.Public = true
 MODULE.Features = {"Adds the ability to shoot door locks to open them", "Adds a quick breach alternative", "Adds a loud action that may alert others", "Adds chance-based lock destruction", "Adds configurable noise radius",}

--- a/simple_lockpicking/module.lua
+++ b/simple_lockpicking/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Lockpicking"
 MODULE.author = "76561198312513285"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Provides a basic lockpick tool for brute forcing doors with logged attempts."
 MODULE.Public = true
 if SERVER then lia.log.addType("lockpick", function(client, target) return string.format("%s lockpicked %s", client:Name(), tostring(target)) end, "Player") end

--- a/slots/module.lua
+++ b/slots/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Slots"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Adds a playable slot machine using a workshop model that pays out winnings."
 MODULE.WorkshopContent = "3482441716"
 MODULE.Public = true

--- a/slowweapons/module.lua
+++ b/slowweapons/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Heavy Weapons"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Slows player movement when wielding specified heavy weapons to encourage tactical choices."
 MODULE.WeaponsSpeed = {
     ["fo3_fatman"] = 130,

--- a/stungun/module.lua
+++ b/stungun/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Stun Gun"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.1.7"
+MODULE.version = 10107
 MODULE.desc = "Adds a configurable taser weapon that stuns targets and can apply damage with post-process effects."
 MODULE.WorkshopContent = "3432649835"
 MODULE.Public = true

--- a/tying/module.lua
+++ b/tying/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Tying"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.10"
+MODULE.version = 10010
 MODULE.desc = "Introduces handcuff-style tying items for arrests and logs all tie or untie actions."
 MODULE.Public = true
 if SERVER then

--- a/tying/submodules/tyingsearch/module.lua
+++ b/tying/submodules/tyingsearch/module.lua
@@ -1,6 +1,6 @@
 ﻿MODULE.name = "Search Tying Sub-Module"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Extends the tying system with the ability to search restrained players and confiscate items."
 MODULE.Features = {"Adds searching of tied players' inventories", "Adds ability to confiscate contraband", "Adds seamless integration with the tying module", "Adds a configurable list of illegal items", "Adds logging of confiscated belongings",}

--- a/viewbob/module.lua
+++ b/viewbob/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "View Bob"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Applies camera bobbing while moving with adjustable strength for immersion."
 MODULE.Public = true
 MODULE.Features = {"Adds camera bobbing while moving", "Adds adjustable intensity", "Adds enhanced immersion", "Adds toggle to disable bobbing in vehicles", "Adds configuration for bobbing frequency",}

--- a/vmanip/module.lua
+++ b/vmanip/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "VManip"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.5"
+MODULE.version = 10005
 MODULE.desc = "Adds support for VManip animations and gestures within the framework."
 MODULE.Public = true
 MODULE.Features = {"Adds VManip animation support", "Adds hand gestures for items", "Adds functionality within Lilia", "Adds API for custom gesture triggers", "Adds fallback animations when VManip is missing",}

--- a/warrants/module.lua
+++ b/warrants/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Warrant"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.10"
+MODULE.version = 10010
 MODULE.desc = "Allows staff to issue and remove player warrants while notifying everyone involved."
 MODULE.CAMIPrivileges = {
     {

--- a/wartable/module.lua
+++ b/wartable/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "War Table"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.7"
+MODULE.version = 10007
 MODULE.desc = "Adds an interactive 3D war table for planning operations on a shared map."
 MODULE.WorkshopContent = "3431351432"
 MODULE.Public = true

--- a/whitelist/module.lua
+++ b/whitelist/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Whitelist"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.4"
+MODULE.version = 10004
 MODULE.desc = "Implements a server whitelist system with optional player signup support."
 MODULE.Public = true
 MODULE.Features = {"Adds a server access whitelist", "Adds toggleable player signups", "Adds a public module for gating entry", "Adds admin commands to manage the list", "Adds notifications on join attempt",}

--- a/wordfilter/module.lua
+++ b/wordfilter/module.lua
@@ -1,7 +1,7 @@
 ﻿MODULE.name = "Word Filter"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
-MODULE.version = "1.0.3"
+MODULE.version = 10003
 MODULE.desc = "Filters unwanted words from chat using a customizable blacklist."
 MODULE.Public = true
 MODULE.Features = {"Adds chat word filtering", "Adds blocking of banned phrases", "Adds an easy-to-extend list", "Adds regex support for advanced filters", "Adds admin commands to modify the list",}


### PR DESCRIPTION
## Summary
- change all `MODULE.version` values from strings to numeric values
- adjust GitHub Actions workflow to parse numeric versions
- update `scrap_modules.js` to convert numeric versions back to `x.y.z` strings for docs

## Testing
- `node scrap_modules.js`

------
https://chatgpt.com/codex/tasks/task_e_6873a42cde388327a582cfe99ff999ec