### PR TITLE
Add hooks for climb, alcoholism, autorestarter

### DIFF
--- a/alcoholism/docs/hooks.md
+++ b/alcoholism/docs/hooks.md
@@ -80,3 +80,55 @@ end)
 
 ---
 
+### AlcoholConsumed
+
+**Purpose**
+Called when a player drinks an alcohol item.
+
+**Parameters**
+
+- `client` (`Player`): The drinking player.
+- `item` (`Item`): Item that was consumed.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+**Example**
+
+```lua
+function MODULE:AlcoholConsumed(client, item)
+    print(client:Name() .. " drank " .. item.name)
+end
+```
+
+---
+
+### BACChanged
+
+**Purpose**
+Fires whenever a player's blood alcohol level changes.
+
+**Parameters**
+
+- `client` (`Player`): Player whose BAC changed.
+- `bac` (`number`): New BAC value (0-100).
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+**Example**
+
+```lua
+function MODULE:BACChanged(client, bac)
+    print("BAC for", client:Name(), "is now", bac)
+end
+```
+
+---
+

--- a/alcoholism/items/base/alcohol.lua
+++ b/alcoholism/items/base/alcohol.lua
@@ -15,6 +15,7 @@ ITEM.functions.use = {
     onRun = function(item)
         local client = item.player
         client:AddBAC(item.abv)
+        hook.Run("AlcoholConsumed", client, item)
         client:EmitSound("vo/npc/male01/drink01.wav", 75, 100)
         return true
     end,

--- a/alcoholism/libraries/server.lua
+++ b/alcoholism/libraries/server.lua
@@ -4,7 +4,11 @@ function MODULE:Think()
     if next_think <= CurTime() then
         for _, client in player.Iterator() do
             local bac = client:getNetVar("lia_alcoholism_bac", 0)
-            if bac > 0 then client:setNetVar("lia_alcoholism_bac", math.Clamp(bac - lia.config.get("AlcoholDegradeRate", 5), 0, 100)) end
+            if bac > 0 then
+                local newBac = math.Clamp(bac - lia.config.get("AlcoholDegradeRate", 5), 0, 100)
+                client:setNetVar("lia_alcoholism_bac", newBac)
+                hook.Run("BACChanged", client, newBac)
+            end
         end
 
         next_think = CurTime() + lia.config.get("AlcoholTickTime", 30)

--- a/alcoholism/meta/sh_player.lua
+++ b/alcoholism/meta/sh_player.lua
@@ -2,11 +2,14 @@
 if SERVER then
     function playerMeta:ResetBAC()
         self:setNetVar("lia_alcoholism_bac", 0)
+        hook.Run("BACChanged", self, 0)
     end
 
     function playerMeta:AddBAC(amt)
         if not amt or not isnumber(amt) then return end
-        self:setNetVar("lia_alcoholism_bac", math.Clamp(self:getNetVar("lia_alcoholism_bac", 0) + amt, 0, 100))
+        local newBac = math.Clamp(self:getNetVar("lia_alcoholism_bac", 0) + amt, 0, 100)
+        self:setNetVar("lia_alcoholism_bac", newBac)
+        hook.Run("BACChanged", self, newBac)
     end
 end
 

--- a/autorestarter/docs/hooks.md
+++ b/autorestarter/docs/hooks.md
@@ -80,3 +80,53 @@ end)
 
 ---
 
+### AutoRestart
+
+**Purpose**
+Called right before the server restarts automatically.
+
+**Parameters**
+
+- `timestamp` (`number`): UNIX time when the restart is executed.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+**Example**
+
+```lua
+function MODULE:AutoRestart(time)
+    print("Restarting at", os.date("%X", time))
+end
+```
+
+---
+
+### AutoRestartCountdown
+
+**Purpose**
+Fires repeatedly during the final quarter of the restart countdown.
+
+**Parameters**
+
+- `remaining` (`number`): Seconds remaining until restart.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+**Example**
+
+```lua
+function MODULE:AutoRestartCountdown(remaining)
+    print("Restart in", remaining, "seconds")
+end
+```
+
+---
+

--- a/autorestarter/libraries/server.lua
+++ b/autorestarter/libraries/server.lua
@@ -14,12 +14,13 @@ function MODULE:InitializedModules()
                 net.Send(ply)
                 notified[ply:SteamID()] = false
             end
-
+            hook.Run("AutoRestart", now)
             game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n")
         else
             local interval = lia.config.get("RestartInterval")
             local remaining = self.nextRestart - now
             if remaining <= interval * 0.25 then
+                hook.Run("AutoRestartCountdown", remaining)
                 for _, ply in player.Iterator() do
                     local id = ply:SteamID()
                     if not notified[id] then

--- a/climb/docs/hooks.md
+++ b/climb/docs/hooks.md
@@ -80,3 +80,29 @@ end)
 
 ---
 
+### PlayerClimbed
+
+**Purpose**
+Triggered after a player successfully climbs a ledge.
+
+**Parameters**
+
+- `client` (`Player`): The climbing player.
+- `height` (`number`): Distance climbed in units.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+**Example**
+
+```lua
+function MODULE:PlayerClimbed(client, height)
+    print(client:Name(), "climbed", height)
+end
+```
+
+---
+

--- a/climb/libraries/server.lua
+++ b/climb/libraries/server.lua
@@ -13,6 +13,7 @@
         if trLo and trHi and trLo.Hit and not trHi.Hit then
             local dist = math.abs(trHi.HitPos.z - ply:GetPos().z)
             ply:SetVelocity(Vector(0, 0, 50 + dist * 3))
+            hook.Run("PlayerClimbed", ply, dist)
         end
     end
 end


### PR DESCRIPTION
## Summary
- trigger a `PlayerClimbed` hook in the climb module
- fire `AlcoholConsumed` and `BACChanged` events in the alcoholism module
- notify via `AutoRestart` and `AutoRestartCountdown` hooks in autorestarter
- document the new hooks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874ce9769388327ad956f3a3eab766b