### PR TITLE
Add additional hooks for module actions

### DIFF
--- a/bodygrouper/netcalls/client.lua
+++ b/bodygrouper/netcalls/client.lua
@@ -4,7 +4,14 @@ net.Receive("BodygrouperMenu", function()
     if IsValid(MODULE.Menu) then MODULE.Menu:Remove() end
     local entity = net.ReadEntity()
     MODULE.Menu = vgui.Create("BodygrouperMenu")
-    MODULE.Menu:SetTarget(IsValid(entity) and entity or client)
+    local target = IsValid(entity) and entity or client
+    MODULE.Menu:SetTarget(target)
+    hook.Run("BodygrouperMenuOpened", MODULE.Menu, target)
 end)
 
-net.Receive("BodygrouperMenuCloseClientside", function() if IsValid(MODULE.Menu) then MODULE.Menu:Remove() end end)
+net.Receive("BodygrouperMenuCloseClientside", function()
+    if IsValid(MODULE.Menu) then
+        MODULE.Menu:Remove()
+        hook.Run("BodygrouperMenuClosed")
+    end
+end)

--- a/bodygrouper/netcalls/server.lua
+++ b/bodygrouper/netcalls/server.lua
@@ -3,6 +3,7 @@ net.Receive("BodygrouperMenuClose", function(_, client)
     for _, v in pairs(ents.FindByClass("lia_bodygrouper")) do
         if v:HasUser(client) then v:RemoveUser(client) end
     end
+    hook.Run("BodygrouperMenuClosedServer", client)
 end)
 
 net.Receive("BodygrouperMenu", function(_, client)
@@ -38,6 +39,7 @@ net.Receive("BodygrouperMenu", function(_, client)
             end
         end
     end
+    hook.Run("PreBodygroupApply", client, target, skn, groups)
 
     local character = target:getChar()
     if not character then return end
@@ -48,6 +50,7 @@ net.Receive("BodygrouperMenu", function(_, client)
     end
 
     character:setData("groups", groups)
+    hook.Run("PostBodygroupApply", client, target, skn, groups)
     if target == client then
         target:notifyLocalized("bodygroupChanged", "your")
     else

--- a/broadcasts/commands.lua
+++ b/broadcasts/commands.lua
@@ -43,6 +43,7 @@
             end
 
             client:notifyLocalized("classBroadcastSent")
+            hook.Run("ClassBroadcastSent", client, message, classListSimple)
             lia.log.add(client, "classbroadcast", message)
         end)
     end,
@@ -93,6 +94,7 @@ lia.command.add("factionbroadcast", {
             end
 
             client:notifyLocalized("factionBroadcastSent")
+            hook.Run("FactionBroadcastSent", client, message, factionListSimple)
             lia.log.add(client, "factionbroadcast", message)
         end)
     end,

--- a/captions/libs/sh_captions.lua
+++ b/captions/libs/sh_captions.lua
@@ -4,11 +4,13 @@
         net.WriteString(text)
         net.WriteFloat(duration)
         net.Send(client)
+        hook.Run("CaptionStarted", client, text, duration)
     end
 
     function lia.caption.finish(client)
         net.Start("EndCaption")
         net.Send(client)
+        hook.Run("CaptionFinished", client)
     end
 
     local networkStrings = {"StartCaption", "EndCaption"}
@@ -19,10 +21,12 @@ else
     function lia.caption.start(text, duration)
         RunConsoleCommand("closecaption", "1")
         gui.AddCaption(text, duration or string.len(text) * 0.1)
+        hook.Run("CaptionStarted", text, duration)
     end
 
     function lia.caption.finish()
         RunConsoleCommand("closecaption", "1")
         gui.AddCaption("", 0)
+        hook.Run("CaptionFinished")
     end
 end

--- a/cards/commands.lua
+++ b/cards/commands.lua
@@ -11,5 +11,6 @@
         local suits = {L("suitSpades"), L("suitDiamonds"), L("suitHearts"), L("suitClubs")}
         local card = table.Random(ranks) .. " " .. table.Random(suits)
         lia.chat.send(client, "me", L("cardDrawAction") .. " " .. card)
+        hook.Run("CardDrawn", client, card)
     end
 })

--- a/chatmessages/libraries/client.lua
+++ b/chatmessages/libraries/client.lua
@@ -8,6 +8,7 @@ function MODULE:InitPostEntity()
         local prefix = CommunityName .. " | "
         local text = messageData
         chat.AddText(Color(255, 0, 0), prefix, color_white, text)
+        hook.Run("ChatMessageSent", nextMessageIndex, text)
         nextMessageIndex = nextMessageIndex % #ChatMessages + 1
     end)
 end


### PR DESCRIPTION
## Summary
- add hooks when bodygrouper menus open, close, and apply bodygroups
- trigger events after faction and class broadcasts
- fire hooks when captions start or finish
- add CardDrawn hook for /cards command
- emit ChatMessageSent on each automated chat message

## Testing
- `luac` not found; unable to run Lua syntax checks

------
https://chatgpt.com/codex/tasks/task_e_6874cea99a548327808d0eb9e365e87d