### PR TITLE
Add action hooks to multiple modules

### DIFF
--- a/loadmessages/libraries/server.lua
+++ b/loadmessages/libraries/server.lua
@@ -1,4 +1,7 @@
 ﻿function MODULE:PlayerLoadedChar(client)
     local data = self.FactionMessages[client:Team()]
-    if data then ClientAddText(client, unpack(data)) end
+    if data then
+        ClientAddText(client, unpack(data))
+        hook.Run("LoadMessageSent", client, data)
+    end
 end

--- a/loyalism/libraries/server.lua
+++ b/loyalism/libraries/server.lua
@@ -9,6 +9,7 @@ function MODULE:UpdatePartyTiers()
         if char then
             local tier = char:getData("party_tier", 0)
             char:setData("party_tier", tier, false, player.GetAll())
+            hook.Run("PartyTierUpdated", ply, tier)
         end
     end
 end

--- a/mapcleaner/libraries/server.lua
+++ b/mapcleaner/libraries/server.lua
@@ -15,6 +15,7 @@
     end)
 
     timer.Create("clearWorldItems", itemCleanupTime, 0, function()
+        hook.Run("PreItemCleanup")
         for _, client in player.Iterator() do
             client:ChatPrint(L("itemCleanupFinalWarning"))
         end
@@ -22,9 +23,11 @@
         for _, item in pairs(ents.FindByClass("lia_item")) do
             item:Remove()
         end
+        hook.Run("PostItemCleanup")
     end)
 
     timer.Create("AutomaticMapCleanup", mapCleanupTime, 0, function()
+        hook.Run("PreMapCleanup")
         for _, client in player.Iterator() do
             client:ChatPrint(L("mapCleanupFinalWarning"))
         end
@@ -32,5 +35,6 @@
         for _, ent in ents.Iterator() do
             if table.HasValue(self.MapCleanerEntitiesToRemove, ent:GetClass()) then ent:Remove() end
         end
+        hook.Run("PostMapCleanup")
     end)
 end

--- a/modelpay/libraries/server.lua
+++ b/modelpay/libraries/server.lua
@@ -6,11 +6,18 @@ function MODULE:GetSalaryAmount(client)
     if not IsValid(client) or not client:getChar() then return 0 end
     local playerModel = string.lower(client:GetModel())
     for model, pay in pairs(ModelPay) do
-        if model:lower() == playerModel then return pay end
+        if model:lower() == playerModel then
+            hook.Run("ModelPaySalaryDetermined", client, pay)
+            return pay
+        end
     end
+    hook.Run("ModelPaySalaryDetermined", client, 0)
     return 0
 end
 
 function MODULE:PlayerModelChanged(client, newModel)
-    if ModelPay[newModel] then hook.Run("CreateSalaryTimer", client) end
+    if ModelPay[newModel] then
+        hook.Run("CreateSalaryTimer", client)
+        hook.Run("ModelPayModelEligible", client, newModel)
+    end
 end

--- a/modeltweaker/libraries/server.lua
+++ b/modeltweaker/libraries/server.lua
@@ -17,8 +17,10 @@ net.Receive("WardrobeChangeModel", function(_, client)
         char:setModel(newModel)
         client:SetModel(newModel)
         client:notifyLocalized("wardrobeModelChanged")
+        hook.Run("WardrobeModelChanged", client, newModel)
     else
         client:notifyLocalized("wardrobeModelInvalid")
+        hook.Run("WardrobeModelInvalid", client, newModel)
     end
 end)
 

--- a/npcdrop/libraries/server.lua
+++ b/npcdrop/libraries/server.lua
@@ -13,6 +13,7 @@ function MODULE:OnNPCKilled(ent)
     for itemName, weight in pairs(weights) do
         if choice <= weight then
             lia.item.spawn(itemName, ent:GetPos() + Vector(0, 0, 16), nil, ent:GetAngles())
+            hook.Run("NPCDroppedItem", ent, itemName)
             return
         end
 


### PR DESCRIPTION
## Summary
- fire `LoadMessageSent` when a load message displays
- call `PartyTierUpdated` whenever loyalty tiers sync
- trigger cleanup hooks in Map Cleaner timers
- report salary determination and eligible models in Model Pay
- emit hooks for wardrobe changes
- announce item drops from NPCs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874cf98cf908327bda31d76e5a39cae