### PR TITLE
Add hooks for module actions

### DIFF
--- a/realisticview/libraries/client.lua
+++ b/realisticview/libraries/client.lua
@@ -31,6 +31,8 @@
         else
             view.angles = Angle(head.Ang.p, head.Ang.y, angles.r)
         end
+
+        hook.Run("RealisticViewCalcView", client, view)
         return view
-    end
-end
+      end
+  end

--- a/rumour/commands.lua
+++ b/rumour/commands.lua
@@ -33,5 +33,7 @@
                 ClientAddText(target, L("rumourMessagePrefix", rumourMessage))
             end
         end
-    end
-})
+
+        hook.Run("RumourSent", client, rumourMessage, revealMath)
+      end
+  })

--- a/shootlock/libraries/server.lua
+++ b/shootlock/libraries/server.lua
@@ -16,6 +16,7 @@
                     effect:SetOrigin(position)
                     effect:SetScale(10)
                     util.Effect("GlassImpact", effect, true, true)
+                    hook.Run("LockShotBreach", client, entity)
                     return
                 end
             end
@@ -34,6 +35,7 @@
                 entity:Fire("unlock")
                 entity:Fire("openawayfrom", name)
                 entity:EmitSound("physics/wood/wood_plank_break" .. math.random(1, 4) .. ".wav", 100, 120)
+                hook.Run("LockShotBreach", client, entity)
                 entity.liaNextBreach = CurTime() + 1
                 timer.Simple(0.5, function() if IsValid(entity) then entity:Fire("setspeed", entity.liaOldSpeed) end end)
             end

--- a/simple_lockpicking/items/lockpick.lua
+++ b/simple_lockpicking/items/lockpick.lua
@@ -10,6 +10,7 @@ ITEM.functions.Use = {
         local target = ply:GetEyeTrace().Entity
         if not ply:getNetVar("restricted") and IsValid(target) or target:IsVehicle() and target:isLocked() then
             item.beingUsed = true
+            hook.Run("LockpickStart", ply, target)
             local timerID = "Lockpicksnd" .. ply:SteamID()
             timer.Create(timerID, 1, 15, function()
                 if not ply or not ply:getNetVar("isPicking") then
@@ -30,11 +31,13 @@ ITEM.functions.Use = {
                 if target:IsVehicle() and target.IsSimfphyscar then target.IsLocked = false end
                 ply:setNetVar("isPicking")
                 timer.Remove(timerID)
+                hook.Run("LockpickSuccess", ply, target)
             end, 15, function()
                 ply:setNetVar("isPicking")
                 ply:setAction()
                 item.beingUsed = false
                 timer.Remove(timerID)
+                hook.Run("LockpickInterrupted", ply, target)
             end)
         else
             item.player:notifyLocalized("targetUnlocked")

--- a/slots/entities/entities/slot_machine/init.lua
+++ b/slots/entities/entities/slot_machine/init.lua
@@ -66,6 +66,7 @@ function ENT:Use(client)
     timer.Create("SpinWheels" .. self:EntIndex(), 0, 1, function()
         self.IsPlaying = false
         character:takeMoney(MODULE.GamblingPrice)
+        hook.Run("SlotMachineStart", self, client)
         self:EmitSound("ambient/levels/labs/coinslot1.wav", 60, 100)
         self:EmitSound("spin.wav", 100, 100)
         for i = 1, 3 do
@@ -123,12 +124,13 @@ function ENT:Use(client)
                 end
             end
 
-            if payout > MODULE.SingleBarDollarSign - 1 then self:EmitSound("jackpot.wav", 100, 100) end
-            if payout > 9 then
-                self:EmitSound("payout.wav", 100, 100)
-                character:giveMoney(payout)
-                client:notifyLocalized("slotPayout", payout)
-            end
+                if payout > MODULE.SingleBarDollarSign - 1 then self:EmitSound("jackpot.wav", 100, 100) end
+                if payout > 9 then
+                    self:EmitSound("payout.wav", 100, 100)
+                    character:giveMoney(payout)
+                    client:notifyLocalized("slotPayout", payout)
+                    hook.Run("SlotMachinePayout", self, client, payout)
+                end
 
             self.IsPlaying = true
             self.Jackpot = false


### PR DESCRIPTION
## Summary
- add `RealisticViewCalcView` hook
- trigger `RumourSent` after rumour broadcasts
- trigger `LockShotBreach` for doors shot open
- fire lockpicking hooks for start, success, and interruption
- announce slot machine start and payouts with hooks

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6874cfa68114832792a3b3d0f62c1667