### PR TITLE
Add runtime hooks for UI and gameplay modules

### DIFF
--- a/compass/libraries/shared.lua
+++ b/compass/libraries/shared.lua
@@ -85,6 +85,7 @@ if SERVER then
         end
 
         table.insert(mCompass_MarkerTable, {id, pos, time, color, icon, name})
+        hook.Run("CompassMarkerAdded", ply, pos, players, time, color, icon, name, id)
         return id
     end
 
@@ -119,6 +120,7 @@ if SERVER then
         end
 
         table.insert(mCompass_MarkerTable, {id, pos, time, color, icon, name})
+        hook.Run("CompassEntityMarkerAdded", ply, ent, players, time, color, icon, name, id)
         return id
     end
 
@@ -129,6 +131,7 @@ if SERVER then
                 net.WriteInt(markerID, 4)
                 net.Broadcast()
                 table.remove(mCompass_MarkerTable, k)
+                hook.Run("CompassMarkerRemoved", markerID)
             end
         end
     end

--- a/corpseid/libraries/server.lua
+++ b/corpseid/libraries/server.lua
@@ -3,7 +3,10 @@
     local targetPlayer = corpse:getNetVar("player")
     if not IsValid(targetPlayer) then return end
     local IDTime = lia.config.get("IdentificationTime", 5)
-    client:setAction(L("identifyingCorpse"), IDTime, function() client:ChatPrint(L("identifiedCorpseMessage", targetPlayer:Nick())) end)
+    client:setAction(L("identifyingCorpse"), IDTime, function()
+        client:ChatPrint(L("identifiedCorpseMessage", targetPlayer:Nick()))
+        hook.Run("CorpseIdentified", client, targetPlayer, corpse)
+    end)
 end
 
 function MODULE:PlayerUse(client, entity)
@@ -26,6 +29,7 @@ function MODULE:DoPlayerDeath(client)
     if IsValid(corpse) then
         corpse:setNetVar("ShowCorpseMessage", true)
         corpse:setNetVar("player", client)
+        hook.Run("CorpseCreated", client, corpse)
     end
 end
 

--- a/cursor/libraries/client.lua
+++ b/cursor/libraries/client.lua
@@ -1,6 +1,9 @@
 ﻿local CursorMaterial = ""
 function MODULE:PostRenderVGUI()
-    if CursorMaterial ~= "" then draw.CustCursor(CursorMaterial) end
+    if CursorMaterial ~= "" then
+        draw.CustCursor(CursorMaterial)
+        hook.Run("PostRenderCursor", CursorMaterial)
+    end
 end
 
 function MODULE:Think()
@@ -8,5 +11,6 @@ function MODULE:Think()
         local hover_panel = vgui.GetHoveredPanel()
         if not IsValid(hover_panel) then return end
         hover_panel:SetCursor("blank")
+        hook.Run("CursorThink", hover_panel)
     end
 end

--- a/cutscenes/libraries/client.lua
+++ b/cutscenes/libraries/client.lua
@@ -2,6 +2,7 @@ local MODULE = MODULE
 function MODULE:runCutscene(id)
     local cs = self.cutscenes[id]
     if not cs then return end
+    hook.Run("CutsceneStarted", id)
     local pl = LocalPlayer()
     local w, h = ScrW(), ScrH()
     local fade = vgui.Create("DPanel")
@@ -86,7 +87,10 @@ function MODULE:runCutscene(id)
             end)
         end
 
-        timer.Simple(self.fadeDelay, function() fade:Remove() end)
+        timer.Simple(self.fadeDelay, function()
+            fade:Remove()
+            hook.Run("CutsceneEnded", id)
+        end)
     end
 
     local t = self.fadeDelay

--- a/cutscenes/libraries/server.lua
+++ b/cutscenes/libraries/server.lua
@@ -1,6 +1,7 @@
 function MODULE:runCutscene(target, id)
     local recipients = target and {target} or player.GetAll()
     for _, ply in pairs(recipients) do
+        hook.Run("CutsceneStarted", ply, id)
         net.Start("lia_cutscene")
         net.WriteString(id)
         net.Send(ply)

--- a/damagenumbers/libraries/client.lua
+++ b/damagenumbers/libraries/client.lua
@@ -34,4 +34,5 @@ net.Receive("expDamageNumbers", function()
         pos = pos,
         color = col
     })
+    hook.Run("DamageNumberAdded", ent, dmg)
 end)

--- a/damagenumbers/libraries/server.lua
+++ b/damagenumbers/libraries/server.lua
@@ -7,6 +7,7 @@
     net.WriteEntity(ent)
     net.WriteUInt(dmg, 32)
     net.Send({ent, atk})
+    hook.Run("DamageNumbersSent", atk, ent, dmg)
 end
 
 local networkStrings = {"expDamageNumbers"}

--- a/developmenthud/libraries/client.lua
+++ b/developmenthud/libraries/client.lua
@@ -16,4 +16,5 @@
         draw.SimpleText("| Trace Pos: " .. math.Round(hitPos.x, 2) .. "," .. math.Round(hitPos.y, 2) .. "," .. math.Round(hitPos.z, 2) .. " | Cur Health: " .. math.Round(client:Health(), 2) .. " | FrameTime: " .. FrameTime() .. " | PING: " .. client:Ping() .. " | ", devFont, x, y2, Color(210, 210, 210, 255), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
         if IsValid(ent) then draw.SimpleText("| Cur Trace: " .. ent:GetClass() .. " | Trace Model: " .. (ent.GetModel and ent:GetModel() or "N/A") .. " | ", devFont, x, y3, Color(210, 210, 210, 255), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER) end
     end
+    hook.Run("DevelopmentHUDPaint", client)
 end


### PR DESCRIPTION
## Summary
- expose new compass events for marker changes
- fire hooks when corpses spawn or get identified
- provide cursor callbacks while rendering/hovering
- emit cutscene start/end hooks
- trigger hooks for damage number creation
- allow other modules to draw on the development HUD

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874cf7a9d1483279fb0568c470b28d6