### PR TITLE
Add action hooks to modules

### DIFF
--- a/extendeddescriptions/docs/hooks.md
+++ b/extendeddescriptions/docs/hooks.md
@@ -12,6 +12,40 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### ExtendedDescriptionOpened
+Fired after the view panel is created when a player opens an extended description.
+
+**Parameters**
+- `ply` (`Player`): The player whose description is being viewed.
+- `frame` (`Panel`): The created frame.
+- `text` (`string`): Description text.
+- `url` (`string`): Reference image URL.
+
+### ExtendedDescriptionEditOpened
+Triggered when the edit menu is opened.
+
+**Parameters**
+- `frame` (`Panel`): The edit frame.
+- `steamName` (`string`): Steam name of the character being edited.
+
+### ExtendedDescriptionEditSubmitted
+Runs when the edit form is submitted.
+
+**Parameters**
+- `steamName` (`string`): Character steam name.
+- `url` (`string`): Reference image URL.
+- `text` (`string`): Description text.
+
+### ExtendedDescriptionUpdated
+Serverside hook fired after a player's description data is updated.
+
+**Parameters**
+- `client` (`Player`): Player whose description changed.
+- `url` (`string`): Reference image URL.
+- `text` (`string`): New description text.
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/extendeddescriptions/netcalls/client.lua
+++ b/extendeddescriptions/netcalls/client.lua
@@ -18,6 +18,7 @@
     local htmlPanel = vgui.Create("DHTML", frame)
     htmlPanel:Dock(FILL)
     if descURL ~= L("openDetDescFallback") then htmlPanel:OpenURL(descURL) end
+    hook.Run("ExtendedDescriptionOpened", ply, frame, descText, descURL)
 end)
 
 net.Receive("SetDetailedDescriptions", function()
@@ -52,6 +53,8 @@ net.Receive("SetDetailedDescriptions", function()
         net.WriteString(textEntry:GetValue())
         net.WriteString(steamName)
         net.SendToServer()
+        hook.Run("ExtendedDescriptionEditSubmitted", steamName, urlEntry:GetValue(), textEntry:GetValue())
         frame:Close()
     end
+    hook.Run("ExtendedDescriptionEditOpened", frame, steamName)
 end)

--- a/extendeddescriptions/netcalls/server.lua
+++ b/extendeddescriptions/netcalls/server.lua
@@ -6,6 +6,7 @@
         if client:SteamName() == callingClientSteamName then
             client:getChar():setData("textDetDescData", text)
             client:getChar():setData("textDetDescDataURL", textEntryURL)
+            hook.Run("ExtendedDescriptionUpdated", client, textEntryURL, text)
         end
     end
 end)

--- a/firstpersoneffects/docs/hooks.md
+++ b/firstpersoneffects/docs/hooks.md
@@ -12,6 +12,22 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### ShouldUseFirstPersonEffects
+Return `false` to disable the effect for the given player.
+
+**Parameters**
+- `player` (`Player`): Player being processed.
+
+### FirstPersonEffectsUpdated
+Called clientside after the view offsets are calculated.
+
+**Parameters**
+- `player` (`Player`): The local player.
+- `posOffset` (`Vector`): Calculated position offset.
+- `angOffset` (`Angle`): Calculated angle offset.
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/firstpersoneffects/libraries/client.lua
+++ b/firstpersoneffects/libraries/client.lua
@@ -13,6 +13,7 @@ function MODULE:CalcView(pl, pos, ang, fov)
     if not IsValid(LocalPlayer()) or IsValid(lia.gui.char) then return end
     if pl:CanOverrideView() or pl:GetViewEntity() ~= pl then return end
     if not lia.option.get("FirstPersonEffects", true) then return end
+    if hook.Run("ShouldUseFirstPersonEffects", pl) == false then return end
     local realTime = RealTime()
     local frameTime = FrameTime()
     local vel = math.floor(twoD(velo(pl)))
@@ -45,6 +46,7 @@ function MODULE:CalcView(pl, pos, ang, fov)
     self.resultAng = LerpAngle(math_Clamp(math_Clamp(frameTime, 1 / 120, 1) * 10, 0, 5), self.resultAng, ang)
     self.currAng = LerpAngle(frameTime * 10, self.currAng, self.targetAng)
     self.currPos = LerpVector(frameTime * 10, self.currPos, self.targetPos)
+    hook.Run("FirstPersonEffectsUpdated", pl, self.currPos, self.currAng)
     return {
         origin = pos + self.currPos,
         angles = self.resultAng + self.currAng,

--- a/flashlight/docs/hooks.md
+++ b/flashlight/docs/hooks.md
@@ -12,6 +12,22 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### CanPlayerToggleFlashlight
+Return `false` to block a flashlight toggle.
+
+**Parameters**
+- `client` (`Player`): Player using the flashlight.
+- `state` (`boolean`): Desired enabled state.
+
+### PlayerToggleFlashlight
+Fired after the flashlight state successfully changes.
+
+**Parameters**
+- `client` (`Player`): Player that toggled.
+- `state` (`boolean`): New state.
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/flashlight/libraries/server.lua
+++ b/flashlight/libraries/server.lua
@@ -1,5 +1,6 @@
 ﻿function MODULE:PlayerSwitchFlashlight(client, isEnabled)
     if not client:getChar() then return false end
+    if hook.Run("CanPlayerToggleFlashlight", client, isEnabled) == false then return false end
     local enabled, needsItem, cooldown = lia.config.get("FlashlightEnabled", true), lia.config.get("FlashlightNeedsItem", true), lia.config.get("FlashlightCooldown", 0.5)
     if not enabled or (client.FlashlightCooldown or 0) >= CurTime() then return false end
     if needsItem then
@@ -8,6 +9,7 @@
                 client:EmitSound(isEnabled and "buttons/button24.wav" or "buttons/button10.wav", 60, isEnabled and 100 or 70)
                 client.FlashlightCooldown = CurTime() + cooldown
                 client:ConCommand("r_shadows " .. (isEnabled and "1" or "0"))
+    hook.Run("PlayerToggleFlashlight", client, isEnabled)
                 return true
             end
         end
@@ -17,5 +19,6 @@
     client:EmitSound(isEnabled and "buttons/button24.wav" or "buttons/button10.wav", 60, isEnabled and 100 or 70)
     client.FlashlightCooldown = CurTime() + cooldown
     client:ConCommand("r_shadows " .. (isEnabled and "1" or "0"))
+    hook.Run("PlayerToggleFlashlight", client, isEnabled)
     return true
 end

--- a/freelook/docs/hooks.md
+++ b/freelook/docs/hooks.md
@@ -12,6 +12,20 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### ShouldUseFreelook
+Return `false` to disable freelook for the player.
+
+**Parameters**
+- `client` (`Player`): Local player.
+
+### FreelookToggled
+Triggered when freelook mode is toggled via the console command.
+
+**Parameters**
+- `state` (`boolean`): `true` when enabled, `false` when disabled.
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/freelook/libraries/client.lua
+++ b/freelook/libraries/client.lua
@@ -38,6 +38,7 @@ end
 function MODULE:InputMouseApply(cmd, x, y)
     local lp = LocalPlayer()
     if not lp:getChar() or not lia.option.get("freelookEnabled") then return end
+    if hook.Run("ShouldUseFreelook", lp) == false then return end
     if not HoldingBind(lp) or IsInSights(lp) or lp:ShouldDrawLocalPlayer() then
         LookX, LookY = 0, 0
         return
@@ -69,5 +70,11 @@ function MODULE:SetupQuickMenu(menu)
     end, lia.option.get("freelookEnabled"))
 end
 
-concommand.Add("+freelook", function() freelooking = true end)
-concommand.Add("-freelook", function() freelooking = false end)
+concommand.Add("+freelook", function()
+    freelooking = true
+    hook.Run("FreelookToggled", true)
+end)
+concommand.Add("-freelook", function()
+    freelooking = false
+    hook.Run("FreelookToggled", false)
+end)


### PR DESCRIPTION
## Summary
- fire hooks when opening or editing extended descriptions
- allow disabling first person effects via hook and signal updates
- add flashlight toggle hooks serverside
- add freelook toggle hooks and optional check
- document new hooks for each module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874cf8b51cc83278befb6106dc076bc