### PR TITLE
Add extra action hooks

### DIFF
--- a/slowweapons/docs/hooks.md
+++ b/slowweapons/docs/hooks.md
@@ -12,6 +12,40 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### OverrideSlowWeaponSpeed
+
+**Purpose**
+Allows overriding the base movement speed when a heavy weapon is equipped.
+
+**Parameters**
+
+- `client` (`Player`): Player carrying the weapon.
+- `weapon` (`Weapon`): Active weapon.
+- `baseSpeed` (`number`): The default base speed value.
+
+**Returns**
+- `number` (optional): New base speed to use.
+
+---
+
+### ApplyWeaponSlowdown
+
+**Purpose**
+Fires when slowdown is applied so other modules can react.
+
+**Parameters**
+
+- `client` (`Player`): Player being slowed.
+- `weapon` (`Weapon`): Active weapon.
+- `moveData` (`CMoveData`): Current move data.
+- `speed` (`number`): Calculated max speed.
+
+**Returns**
+- None
+
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/slowweapons/libraries/server.lua
+++ b/slowweapons/libraries/server.lua
@@ -3,8 +3,11 @@
     if not IsValid(wep) then return end
     local baseSpeed = self.WeaponsSpeed[wep:GetClass()]
     if not baseSpeed then return end
+    local override = hook.Run("OverrideSlowWeaponSpeed", client, wep, baseSpeed)
+    if isnumber(override) then baseSpeed = override end
     local walkRatio = lia.config.get("WalkRatio")
     local speed = moveData:KeyDown(IN_WALK) and baseSpeed * walkRatio or baseSpeed
+    hook.Run("ApplyWeaponSlowdown", client, wep, moveData, speed)
     moveData:SetMaxSpeed(speed)
     moveData:SetMaxClientSpeed(speed)
 end

--- a/stungun/docs/hooks.md
+++ b/stungun/docs/hooks.md
@@ -12,6 +12,86 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### StunGunFired
+
+**Purpose**
+Triggered when the stungun successfully tases a target.
+
+**Parameters**
+
+- `attacker` (`Player`): Player using the stungun.
+- `target` (`Entity`): Target that was hit.
+
+---
+
+### PlayerStunned
+
+**Purpose**
+Called when a player enters the normal stun state.
+
+**Parameters**
+
+- `target` (`Player`): Player being stunned.
+- `weapon` (`Weapon`): Stungun weapon.
+
+**Returns**
+- None
+
+---
+
+### PlayerStunCleared
+
+**Purpose**
+Fires when a normal stun ends.
+
+**Parameters**
+
+- `target` (`Player`): Stunned player.
+- `weapon` (`Weapon`): Stungun weapon.
+
+---
+
+### PlayerOverStunned
+
+**Purpose**
+Called when a player is over stunned and takes damage.
+
+**Parameters**
+
+- `target` (`Player`): Affected player.
+- `weapon` (`Weapon`): Stungun weapon.
+
+---
+
+### PlayerOverStunCleared
+
+**Purpose**
+Fires when the over stun effect wears off.
+
+**Parameters**
+
+- `target` (`Player`): Player affected.
+- `weapon` (`Weapon`): Stungun weapon.
+
+---
+
+### StunGunTethered
+
+**Purpose**
+Runs when a rope tether is attached between the user and the target.
+
+**Parameters**
+
+- `attacker` (`Player`): Player using the stungun.
+- `target` (`Entity`): Tethered target.
+
+**Returns**
+- None
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/stungun/entities/weapons/weapon_stungun.lua
+++ b/stungun/entities/weapons/weapon_stungun.lua
@@ -111,9 +111,11 @@ function SWEP:FuckingStun(ply, tims)
     if not IsValid(ply) or not ply:IsPlayer() then return end
     ply:SetMoveType(MOVETYPE_FLYGRAVITY)
     ply:EmitSound(GetSound(ply:isFemale()))
+    hook.Run("PlayerStunned", ply, self)
     timer.Create("antistun" .. ply:SteamID(), 1, 1, function()
         if IsValid(ply) then ply:SetMoveType(MOVETYPE_WALK) end
         if IsValid(self) then self.Taser = false end
+        hook.Run("PlayerStunCleared", ply, self)
     end)
 
     net.Start("fucking_stun")
@@ -127,11 +129,13 @@ function SWEP:FuckingOverStun(ply)
     ply:TakeDamage(lia.config.get("Damage"), nil, nil)
     ply:Freeze(true)
     ply:EmitSound(GetSound(ply:isFemale()))
+    hook.Run("PlayerOverStunned", ply, self)
     timer.Create("antistun2" .. ply:SteamID(), lia.config.get("StunTime"), 1, function()
         if IsValid(ply) then
             ply:SetMoveType(MOVETYPE_WALK)
             ply:Freeze(false)
         end
+        hook.Run("PlayerOverStunCleared", ply, self)
     end)
 
     net.Start("fucking_stun2")
@@ -263,6 +267,7 @@ function SWEP:PrimaryAttack()
             if not self.Taser then
                 self.Taser = true
                 self:FuckingStun(self.Target, 0.9)
+                hook.Run("StunGunFired", owner, self.Target)
             end
         else
             self:EmitSound("weapons/clipempty_rifle.wav")
@@ -284,6 +289,7 @@ function SWEP:PrimaryAttack()
             local posLocal = target.HelpEnt:WorldToLocal(owner:GetEyeTrace().HitPos)
             constraint.Rope(self.ent, target.HelpEnt, 0, 0, Vector(0.1, 0.1, 0), posLocal, self.dist, 80, 0, 1, "cable/blue_elec", false)
             constraint.Rope(self.ent, target.HelpEnt, 0, 0, Vector(-0.1, -0.1, 0), posLocal, self.dist, 80, 0, 1, "cable/redlaser", false)
+            hook.Run("StunGunTethered", owner, target)
         elseif not self.Target then
             self:CreateFakeRope()
         end

--- a/tying/docs/hooks.md
+++ b/tying/docs/hooks.md
@@ -12,6 +12,33 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### PlayerHandcuffed
+
+**Purpose**
+Called after a player is fully restrained with handcuffs.
+
+**Parameters**
+
+- `target` (`Player`): The player that was cuffed.
+
+---
+
+### PlayerUnhandcuffed
+
+**Purpose**
+Fires once handcuffs are removed.
+
+**Parameters**
+
+- `target` (`Player`): The player released from cuffs.
+
+**Returns**
+- None
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/tying/libraries/server.lua
+++ b/tying/libraries/server.lua
@@ -92,12 +92,14 @@ function HandcuffPlayer(target)
     end)
 
     target:StartHandcuffAnim()
+    hook.Run("PlayerHandcuffed", target)
 end
 
 function OnHandcuffRemove(target)
     target:setNetVar("restricted", false)
     hook.Run("ResetSubModuleCuffData", target)
     target:EndHandcuffAnim()
+    hook.Run("PlayerUnhandcuffed", target)
 end
 
 function MODULE:CanPlayerJoinClass(client)

--- a/viewbob/docs/hooks.md
+++ b/viewbob/docs/hooks.md
@@ -12,6 +12,25 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### ViewBobPunch
+
+**Purpose**
+Triggered before view punch angles are applied so you can modify them.
+
+**Parameters**
+
+- `player` (`Player`): Local player receiving the effect.
+- `angleX` (`number`): Pitch value passed in.
+- `angleY` (`number`): Yaw value passed in.
+- `angleZ` (`number`): Roll value passed in.
+
+**Returns**
+- None
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/viewbob/libraries/client.lua
+++ b/viewbob/libraries/client.lua
@@ -1,5 +1,6 @@
 ﻿local stepvalue = 0
 local function applyViewPunch(client, angleX, angleY, angleZ)
+    hook.Run("ViewBobPunch", client, angleX, angleY, angleZ)
     if IsValid(client) then client:ViewPunch(Angle(angleX, angleY, angleZ)) end
 end
 

--- a/vmanip/docs/hooks.md
+++ b/vmanip/docs/hooks.md
@@ -12,6 +12,34 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### VManipPickup
+
+**Purpose**
+Called on the server when a player picks up an item and the pickup animation is triggered.
+
+**Parameters**
+
+- `player` (`Player`): Player picking up the item.
+- `item` (`Item`): Item being taken.
+
+---
+
+### VManipAnimationPlayed
+
+**Purpose**
+Fires on the client after the pickup animation plays.
+
+**Parameters**
+
+- `itemID` (`string`): Identifier of the item that triggered the animation.
+
+**Returns**
+- None
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/vmanip/libraries/server.lua
+++ b/vmanip/libraries/server.lua
@@ -4,6 +4,7 @@
         net.Start("PlayPickupAnimation")
         net.WriteString(item.uniqueID)
         net.Send(client)
+        hook.Run("VManipPickup", client, item)
     end
 end
 

--- a/vmanip/netcalls/client.lua
+++ b/vmanip/netcalls/client.lua
@@ -3,5 +3,8 @@
     local itemID = net.ReadString()
     local item = lia.item.list[itemID]
     local isDisabled = item.VManipDisabled
-    if item and VManip.PlayAnim and not isDisabled then VManip:PlayAnim("interactslower") end
+    if item and VManip.PlayAnim and not isDisabled then
+        VManip:PlayAnim("interactslower")
+        hook.Run("VManipAnimationPlayed", itemID)
+    end
 end)

--- a/warrants/docs/hooks.md
+++ b/warrants/docs/hooks.md
@@ -12,6 +12,24 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### WarrantStatusChanged
+
+**Purpose**
+Called whenever a player's warrant state toggles on or off.
+
+**Parameters**
+
+- `character` (`Character`): Character whose status changed.
+- `warranter` (`Player`): Player issuing or removing the warrant.
+- `state` (`boolean`): `true` if warranted, `false` if cleared.
+
+**Returns**
+- None
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/warrants/meta/sh_player.lua
+++ b/warrants/meta/sh_player.lua
@@ -3,6 +3,7 @@ if SERVER then
     function characterMeta:ToggleWanted(warranter)
         local warranted = not self:IsWanted()
         self:setData("wanted", warranted)
+        hook.Run("WarrantStatusChanged", self, warranter, warranted)
         local notificationMessage = warranted and L("WarrantIssued") or L("WarrantRemoved")
         self:notify(notificationMessage)
         if IsValid(warranter) then


### PR DESCRIPTION
## Summary
- fire new hooks when heavy weapon speed is modified
- add tasing hooks and rope tether events
- fire events when players are handcuffed or released
- expose view punch hook
- emit hooks during VManip pickup animations
- provide warrant status change hook
- document the new hooks for each module

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874cfaf11388327a8ba0b623f6ec666