### PR TITLE
Add hook events for War Table, Whitelist and Word Filter

### DIFF
--- a/wartable/docs/hooks.md
+++ b/wartable/docs/hooks.md
@@ -12,6 +12,91 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+### WarTableUsed
+
+**Purpose**
+Called when a player interacts with a war table entity.
+
+**Parameters**
+
+- `client` (`Player`): The player who used the table.
+- `ent` (`Entity`): The war table entity.
+- `holdingSpeed` (`boolean`): Whether the player was holding the sprint key.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+### WarTableCleared
+
+**Purpose**
+Fired after the markers on a war table are cleared.
+
+**Parameters**
+
+- `client` (`Player`): The player who cleared the table.
+- `ent` (`Entity`): The war table entity.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+### WarTableMapChanged
+
+**Purpose**
+Triggered when the map image is changed on a war table.
+
+**Parameters**
+
+- `client` (`Player`): The player who set the map.
+- `ent` (`Entity`): The war table entity.
+- `url` (`string`): URL of the new map image.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+### WarTableMarkerPlaced
+
+**Purpose**
+Runs after a marker is placed on the table.
+
+**Parameters**
+
+- `client` (`Player`): The player placing the marker.
+- `marker` (`Entity`): The created marker entity.
+- `ent` (`Entity`): The war table entity.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+### WarTableMarkerRemoved
+
+**Purpose**
+Runs after a marker is removed from the table.
+
+**Parameters**
+
+- `client` (`Player`): The player removing the marker.
+- `marker` (`Entity`): The marker entity removed.
+- `ent` (`Entity`): The war table entity.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/wartable/entities/entities/wartable/init.lua
+++ b/wartable/entities/entities/wartable/init.lua
@@ -6,4 +6,5 @@ function ENT:Use(activator)
     net.WriteEntity(self)
     net.WriteBool(activator:KeyDown(IN_SPEED))
     net.Send(activator)
+    hook.Run("WarTableUsed", activator, self, activator:KeyDown(IN_SPEED))
 end

--- a/wartable/netcalls/server.lua
+++ b/wartable/netcalls/server.lua
@@ -10,6 +10,7 @@ net.Receive("ClearWarTable", function(_, client)
     local tableEnt = getTableEnt(client:GetPos())
     if not tableEnt then return end
     tableEnt:Clear()
+    hook.Run("WarTableCleared", client, tableEnt)
 end)
 
 net.Receive("SetWarTableMap", function(_, client)
@@ -23,6 +24,7 @@ net.Receive("SetWarTableMap", function(_, client)
             net.WriteEntity(tableEnt)
             net.WriteString(text)
             net.Broadcast()
+            hook.Run("WarTableMapChanged", client, tableEnt, text)
             break
         end
     end
@@ -49,6 +51,7 @@ net.Receive("PlaceWarTableMarker", function(_, client)
 
     marker:SetParent(tableEnt)
     marker:SetMoveType(MOVETYPE_NONE)
+    hook.Run("WarTableMarkerPlaced", client, marker, tableEnt)
 end)
 
 net.Receive("RemoveWarTableMarker", function(_, client)
@@ -56,6 +59,7 @@ net.Receive("RemoveWarTableMarker", function(_, client)
     local tableEnt = getTableEnt(client:GetPos())
     if not tableEnt then return end
     ent:Remove()
+    hook.Run("WarTableMarkerRemoved", client, ent, tableEnt)
 end)
 
 local networkStrings = {"ClearWarTable", "SetWarTableMap", "PlaceWarTableMarker", "RemoveWarTableMarker", "UseWarTable"}

--- a/whitelist/docs/hooks.md
+++ b/whitelist/docs/hooks.md
@@ -12,6 +12,37 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+### PlayerBlacklisted
+
+**Purpose**
+Called when a connecting player's SteamID is on the blacklist.
+
+**Parameters**
+
+- `steamID64` (`string`): The player's 64-bit SteamID.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+### PlayerNotWhitelisted
+
+**Purpose**
+Called when a connecting player is not found in the whitelist.
+
+**Parameters**
+
+- `steamID64` (`string`): The player's 64-bit SteamID.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/whitelist/libraries/server.lua
+++ b/whitelist/libraries/server.lua
@@ -1,6 +1,12 @@
-﻿function MODULE:CheckPassword(steamID64)
+function MODULE:CheckPassword(steamID64)
     local whitelistEnabled = lia.config.get("WhitelistEnabled")
     local blacklistEnabled = lia.config.get("BlacklistedEnabled")
-    if blacklistEnabled and table.HasValue(self.BlacklistedSteamID64, steamID64) then return false, L("blacklistKick") end
-    if whitelistEnabled and not table.HasValue(self.WhitelistedSteamID64, steamID64) then return false, L("whitelistKick", GetHostName()) end
+    if blacklistEnabled and table.HasValue(self.BlacklistedSteamID64, steamID64) then
+        hook.Run("PlayerBlacklisted", steamID64)
+        return false, L("blacklistKick")
+    end
+    if whitelistEnabled and not table.HasValue(self.WhitelistedSteamID64, steamID64) then
+        hook.Run("PlayerNotWhitelisted", steamID64)
+        return false, L("whitelistKick", GetHostName())
+    end
 end

--- a/wordfilter/docs/hooks.md
+++ b/wordfilter/docs/hooks.md
@@ -12,6 +12,32 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+### FilteredWordUsed
+
+**Purpose**
+Triggered when a player's chat message contains a banned word.
+
+**Parameters**
+
+- `client` (`Player`): Player that sent the message.
+- `word` (`string`): The blocked word that was found.
+- `text` (`string`): The full chat message.
+
+**Realm**
+`Server`
+
+**Returns**
+- None
+
+**Example**
+
+```lua
+hook.Add("FilteredWordUsed", "LogFilteredWord", function(client, word, msg)
+    print(client:Nick() .. " tried to say: " .. msg)
+end)
+```
+
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/wordfilter/libraries/shared.lua
+++ b/wordfilter/libraries/shared.lua
@@ -3,6 +3,7 @@ function MODULE:PlayerSay(ply, text)
     local lowerText = text:lower()
     for _, bad in pairs(blacklist) do
         if lowerText:find(bad, 1, true) then
+            hook.Run("FilteredWordUsed", ply, bad, text)
             ply:notifyLocalized("usedFilteredWord")
             return ""
         end


### PR DESCRIPTION
## Summary
- allow hooking when a message contains a filtered word
- document the `FilteredWordUsed` hook
- run hooks when a player fails the whitelist/blacklist check
- document new `PlayerBlacklisted` and `PlayerNotWhitelisted` hooks
- trigger hooks for war table actions (use, clear, map, markers)
- document new war table action hooks

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d13457e48327bc9a7d4c176cecd7