### PR TITLE
Add event hooks

### DIFF
--- a/advert/commands.lua
+++ b/advert/commands.lua
@@ -24,6 +24,7 @@
                 local displayedName = client:getChar():getDisplayedName(ply)
                 ClientAddText(ply, Color(216, 190, 18), L("AdvertFormat", displayedName), Color(255, 255, 255), message)
             end
+            hook.Run("AdvertSent", client, message)
         else
             client:notifyLocalized("AdvertInsufficientFunds")
         end

--- a/alcoholism/meta/sh_player.lua
+++ b/alcoholism/meta/sh_player.lua
@@ -3,6 +3,7 @@ if SERVER then
     function playerMeta:ResetBAC()
         self:setNetVar("lia_alcoholism_bac", 0)
         hook.Run("BACChanged", self, 0)
+        hook.Run("BACReset", self)
     end
 
     function playerMeta:AddBAC(amt)
@@ -10,6 +11,7 @@ if SERVER then
         local newBac = math.Clamp(self:getNetVar("lia_alcoholism_bac", 0) + amt, 0, 100)
         self:setNetVar("lia_alcoholism_bac", newBac)
         hook.Run("BACChanged", self, newBac)
+        hook.Run("BACIncreased", self, amt, newBac)
     end
 end
 

--- a/autorestarter/libraries/server.lua
+++ b/autorestarter/libraries/server.lua
@@ -3,11 +3,13 @@ MODULE.nextRestart = MODULE.nextRestart or 0
 local notified = {}
 function MODULE:InitializedModules()
     self.nextRestart = os.time() + lia.config.get("RestartInterval")
+    hook.Run("AutoRestartScheduled", self.nextRestart)
     timer.Remove("AutoRestarter_Timer")
     timer.Create("AutoRestarter_Timer", 1, 0, function()
         local now = os.time()
         if now >= self.nextRestart then
             self.nextRestart = now + lia.config.get("RestartInterval")
+            hook.Run("AutoRestartScheduled", self.nextRestart)
             for _, ply in player.Iterator() do
                 net.Start("RestartDisplay")
                 net.WriteInt(self.nextRestart, 32)
@@ -15,6 +17,7 @@ function MODULE:InitializedModules()
                 notified[ply:SteamID()] = false
             end
             hook.Run("AutoRestart", now)
+            hook.Run("AutoRestartStarted", game.GetMap())
             game.ConsoleCommand("changelevel " .. game.GetMap() .. "\n")
         else
             local interval = lia.config.get("RestartInterval")

--- a/bodygrouper/libraries/server.lua
+++ b/bodygrouper/libraries/server.lua
@@ -3,11 +3,13 @@ local BodygrouperCloseSound = "doors/door_metal_thin_close2.wav"
 function MODULE:BodygrouperClosetAddUser(closet)
     local opensound = BodygrouperOpenSound
     if opensound then closet:EmitSound(opensound) end
+    hook.Run("BodygrouperClosetOpened", closet)
 end
 
 function MODULE:BodygrouperClosetRemoveUser(closet)
     local closesound = BodygrouperCloseSound
     if closesound then closet:EmitSound(closesound) end
+    hook.Run("BodygrouperClosetClosed", closet)
 end
 
 local networkStrings = {"BodygrouperMenu", "BodygrouperMenuClose", "BodygrouperMenuCloseClientside"}

--- a/broadcasts/commands.lua
+++ b/broadcasts/commands.lua
@@ -34,6 +34,8 @@
                 return
             end
 
+            hook.Run("PreClassBroadcastSend", client, message, classListSimple)
+
             for _, ply in player.Iterator() do
                 if ply == client or ply:getChar() and classList[ply:getChar():getClass()] and SERVER then
                     local displayName = ply:getChar() and ply:getChar():getDisplayedName(client)
@@ -84,6 +86,8 @@ lia.command.add("factionbroadcast", {
                 client:notifyLocalized("factionBroadcastNoValidFactions")
                 return
             end
+
+            hook.Run("PreFactionBroadcastSend", client, message, factionListSimple)
 
             for _, ply in player.Iterator() do
                 if ply == client or ply:getChar() and factionList[ply:getChar():getFaction()] and SERVER then

--- a/captions/commands.lua
+++ b/captions/commands.lua
@@ -17,6 +17,7 @@
         end
 
         if text then
+            hook.Run("SendCaptionCommand", client, target, text, duration)
             lia.caption.start(target, text, duration)
         else
             client:notifyLocalized("sendCaptionError")
@@ -32,6 +33,7 @@ lia.command.add("broadcastCaption", {
         local text = arguments[1]
         local duration = tonumber(arguments[2]) or 5
         if text then
+            hook.Run("BroadcastCaptionCommand", client, text, duration)
             for _, target in player.Iterator() do
                 lia.caption.start(target, text, duration)
             end

--- a/cards/commands.lua
+++ b/cards/commands.lua
@@ -1,6 +1,7 @@
 ﻿lia.command.add("cards", {
     desc = L("cardsCommandDesc"),
     onRun = function(client)
+        hook.Run("CardsCommandUsed", client)
         local inv = client:getChar():getInv()
         if not inv:hasItem("carddeck") then
             client:notify(L("noCardDeck"))

--- a/chatmessages/libraries/client.lua
+++ b/chatmessages/libraries/client.lua
@@ -3,6 +3,7 @@ local CommunityName = "A Lilia Server"
 local ChatMessages = {"Thank you for playing!", "If you need staff, send them a message @ message!"}
 function MODULE:InitPostEntity()
     local interval = lia.config.get("ChatMessagesInterval", 300)
+    hook.Run("ChatMessagesTimerStarted", interval)
     timer.Create("MessageTimer", interval, 0, function()
         local messageData = ChatMessages[nextMessageIndex]
         local prefix = CommunityName .. " | "


### PR DESCRIPTION
## Summary
- add hook to advertise when an advert is sent
- add BACReset and BACIncreased hooks to alcoholism
- add AutoRestart hooks when scheduling and starting restarts
- add closet opened/closed hooks to bodygrouper
- add pre-broadcast hooks to broadcast commands
- add caption command hooks
- add card command hook
- add chat message timer start hook

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d23e057c832790e0f3b382f13e02