### PR TITLE
Add action hooks

### DIFF
--- a/developmentserver/libraries/server.lua
+++ b/developmentserver/libraries/server.lua
@@ -2,6 +2,8 @@
     if lia.config.get("DevServer", false) and not table.HasValue(self.AuthorizedDevelopers, steamid64) then
         hook.Run("DevServerUnauthorized", steamid64)
         return false, L("devServerUnauthorized")
+    else
+        hook.Run("DevServerAuthorized", steamid64)
     end
 end
 
@@ -9,5 +11,7 @@ function MODULE:InitializedModules()
     if lia.config.get("DevServer", false) then
         lia.information(L("devServerActive"))
         hook.Run("DevServerModeActivated")
+    else
+        hook.Run("DevServerModeDeactivated")
     end
 end

--- a/discordrelay/libraries/server.lua
+++ b/discordrelay/libraries/server.lua
@@ -3,6 +3,7 @@ if util.IsBinaryModuleInstalled("chttp") then
     require("chttp")
     function MODULE:OnServerLog(_, _, logString)
         if DiscordWebhook == "" then return end
+        hook.Run("DiscordRelaySend", logString)
         CHTTP({
             url = DiscordWebhook,
             method = "POST",
@@ -19,4 +20,5 @@ if util.IsBinaryModuleInstalled("chttp") then
 else
     print(L("relayCHTTPMissing"))
     print(L("relayInstallPrompt"))
+    hook.Run("DiscordRelayUnavailable")
 end

--- a/donator/libraries/server.lua
+++ b/donator/libraries/server.lua
@@ -102,6 +102,7 @@ concommand.Add("lia_givemoney", function(ply, _, args)
     end
 
     char:giveMoney(amount)
+    hook.Run("DonatorMoneyGiven", target, amount)
     print(L("gaveMoney", amount, target:Nick()))
 end)
 
@@ -127,6 +128,7 @@ concommand.Add("lia_giveflags", function(ply, _, args)
     end
 
     char:giveFlags(flags)
+    hook.Run("DonatorFlagsGiven", target, flags)
     print(L("gaveFlags", flags, target:Nick()))
 end)
 
@@ -158,5 +160,6 @@ concommand.Add("lia_giveitem", function(ply, _, args)
     end
 
     inv:add(uniqueID)
+    hook.Run("DonatorItemGiven", target, uniqueID)
     print(L("gaveItem", uniqueID, target:Nick()))
 end)

--- a/donator/meta/sh_player.lua
+++ b/donator/meta/sh_player.lua
@@ -7,10 +7,12 @@ if SERVER then
     function playerMeta:SetAdditionalCharSlots(val)
         self:setLiliaData("AdditionalCharSlots", val)
         self:saveLiliaData()
+        hook.Run("DonatorAdditionalSlotsSet", self, val)
     end
 
     function playerMeta:GiveAdditionalCharSlots(AddValue)
         AddValue = math.max(0, AddValue or 1)
         self:SetAdditionalCharSlots(self:GetAdditionalCharSlots() + AddValue)
+        hook.Run("DonatorAdditionalSlotsGiven", self, AddValue)
     end
 end

--- a/doorkick/commands.lua
+++ b/doorkick/commands.lua
@@ -6,11 +6,13 @@ lia.command.add("doorkick", {
         local ent = client:GetEyeTraceNoCursor().Entity
         if IsValid(ent) and ent:isDoor() and ent:getNetVar("disabled", false) then
             client:notifyLocalized("doorKickDisabled")
+            hook.Run("DoorKickFailed", client, ent, "disabled")
             return
         end
 
         if table.HasValue(MODULE.KickDoorBlacklistedFactions, client:Team()) then
             client:notifyLocalized("doorKickTooWeak")
+            hook.Run("DoorKickFailed", client, ent, "weak")
             return
         end
 
@@ -41,14 +43,18 @@ lia.command.add("doorkick", {
                     end)
                 else
                     client:notifyLocalized("doorKickCannotKick")
+                    hook.Run("DoorKickFailed", client, ent, "cannotKick")
                 end
             elseif dist <= 60 then
                 client:notifyLocalized("doorKickTooClose")
+                hook.Run("DoorKickFailed", client, ent, "tooClose")
             else
                 client:notifyLocalized("doorKickTooFar")
+                hook.Run("DoorKickFailed", client, ent, "tooFar")
             end
         else
             client:notifyLocalized("doorKickInvalid")
+            hook.Run("DoorKickFailed", client, ent, "invalid")
         end
     end
 })

--- a/enhanceddeath/libraries/server.lua
+++ b/enhanceddeath/libraries/server.lua
@@ -12,6 +12,7 @@
                 local moneyLoss = math.ceil(currentMoney * moneyLossPercentage)
                 if moneyLoss > 0 then
                     client:getChar():takeMoney(moneyLoss)
+                    hook.Run("HospitalMoneyLost", client, moneyLoss)
                     client:notifyLocalized("moneyLossMessage", lia.currency.get(moneyLoss))
                 end
             end


### PR DESCRIPTION
## Summary
- hook into dev server mode checks and initialization
- notify when Discord relay posts or fails
- flag donator actions with new events
- mark door kick failures with reasons
- track hospital money loss

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874d24d4fc08327903c197a92f32e30