### PR TITLE
Add action hooks to several modules

### DIFF
--- a/extendeddescriptions/docs/hooks.md
+++ b/extendeddescriptions/docs/hooks.md
@@ -23,12 +23,26 @@ Fired after the view panel is created when a player opens an extended descriptio
 - `text` (`string`): Description text.
 - `url` (`string`): Reference image URL.
 
+### ExtendedDescriptionClosed
+Triggered when the view panel is closed.
+
+**Parameters**
+- `ply` (`Player`): The player whose description was viewed.
+- `text` (`string`): Description text.
+- `url` (`string`): Reference image URL.
+
 ### ExtendedDescriptionEditOpened
 Triggered when the edit menu is opened.
 
 **Parameters**
 - `frame` (`Panel`): The edit frame.
 - `steamName` (`string`): Steam name of the character being edited.
+
+### ExtendedDescriptionEditClosed
+Runs when the edit menu is closed without submitting.
+
+**Parameters**
+- `steamName` (`string`): Character steam name.
 
 ### ExtendedDescriptionEditSubmitted
 Runs when the edit form is submitted.
@@ -37,6 +51,14 @@ Runs when the edit form is submitted.
 - `steamName` (`string`): Character steam name.
 - `url` (`string`): Reference image URL.
 - `text` (`string`): Description text.
+
+### PreExtendedDescriptionUpdate
+Serverside hook fired before a player's description data updates.
+
+**Parameters**
+- `client` (`Player`): Player whose description is changing.
+- `url` (`string`): Reference image URL.
+- `text` (`string`): New description text.
 
 ### ExtendedDescriptionUpdated
 Serverside hook fired after a player's description data is updated.

--- a/extendeddescriptions/netcalls/client.lua
+++ b/extendeddescriptions/netcalls/client.lua
@@ -18,6 +18,9 @@
     local htmlPanel = vgui.Create("DHTML", frame)
     htmlPanel:Dock(FILL)
     if descURL ~= L("openDetDescFallback") then htmlPanel:OpenURL(descURL) end
+    frame.OnRemove = function()
+        hook.Run("ExtendedDescriptionClosed", ply, descText, descURL)
+    end
     hook.Run("ExtendedDescriptionOpened", ply, frame, descText, descURL)
 end)
 
@@ -55,6 +58,9 @@ net.Receive("SetDetailedDescriptions", function()
         net.SendToServer()
         hook.Run("ExtendedDescriptionEditSubmitted", steamName, urlEntry:GetValue(), textEntry:GetValue())
         frame:Close()
+    end
+    frame.OnRemove = function()
+        hook.Run("ExtendedDescriptionEditClosed", steamName)
     end
     hook.Run("ExtendedDescriptionEditOpened", frame, steamName)
 end)

--- a/extendeddescriptions/netcalls/server.lua
+++ b/extendeddescriptions/netcalls/server.lua
@@ -4,6 +4,7 @@
     local callingClientSteamName = net.ReadString()
     for _, client in player.Iterator() do
         if client:SteamName() == callingClientSteamName then
+            hook.Run("PreExtendedDescriptionUpdate", client, textEntryURL, text)
             client:getChar():setData("textDetDescData", text)
             client:getChar():setData("textDetDescDataURL", textEntryURL)
             hook.Run("ExtendedDescriptionUpdated", client, textEntryURL, text)

--- a/firstpersoneffects/docs/hooks.md
+++ b/firstpersoneffects/docs/hooks.md
@@ -20,6 +20,20 @@ Return `false` to disable the effect for the given player.
 **Parameters**
 - `player` (`Player`): Player being processed.
 
+### PreFirstPersonEffects
+Called clientside before view offsets are calculated.
+
+**Parameters**
+- `player` (`Player`): The local player.
+
+### PostFirstPersonEffects
+Called clientside after view offsets are calculated.
+
+**Parameters**
+- `player` (`Player`): The local player.
+- `posOffset` (`Vector`): Calculated position offset.
+- `angOffset` (`Angle`): Calculated angle offset.
+
 ### FirstPersonEffectsUpdated
 Called clientside after the view offsets are calculated.
 

--- a/firstpersoneffects/libraries/client.lua
+++ b/firstpersoneffects/libraries/client.lua
@@ -14,6 +14,7 @@ function MODULE:CalcView(pl, pos, ang, fov)
     if pl:CanOverrideView() or pl:GetViewEntity() ~= pl then return end
     if not lia.option.get("FirstPersonEffects", true) then return end
     if hook.Run("ShouldUseFirstPersonEffects", pl) == false then return end
+    hook.Run("PreFirstPersonEffects", pl)
     local realTime = RealTime()
     local frameTime = FrameTime()
     local vel = math.floor(twoD(velo(pl)))
@@ -46,6 +47,7 @@ function MODULE:CalcView(pl, pos, ang, fov)
     self.resultAng = LerpAngle(math_Clamp(math_Clamp(frameTime, 1 / 120, 1) * 10, 0, 5), self.resultAng, ang)
     self.currAng = LerpAngle(frameTime * 10, self.currAng, self.targetAng)
     self.currPos = LerpVector(frameTime * 10, self.currPos, self.targetPos)
+    hook.Run("PostFirstPersonEffects", pl, self.currPos, self.currAng)
     hook.Run("FirstPersonEffectsUpdated", pl, self.currPos, self.currAng)
     return {
         origin = pos + self.currPos,

--- a/flashlight/docs/hooks.md
+++ b/flashlight/docs/hooks.md
@@ -21,6 +21,13 @@ Return `false` to block a flashlight toggle.
 - `client` (`Player`): Player using the flashlight.
 - `state` (`boolean`): Desired enabled state.
 
+### PrePlayerToggleFlashlight
+Called before the flashlight state changes.
+
+**Parameters**
+- `client` (`Player`): Player toggling.
+- `state` (`boolean`): Desired enabled state.
+
 ### PlayerToggleFlashlight
 Fired after the flashlight state successfully changes.
 

--- a/flashlight/libraries/server.lua
+++ b/flashlight/libraries/server.lua
@@ -1,5 +1,6 @@
-﻿function MODULE:PlayerSwitchFlashlight(client, isEnabled)
+function MODULE:PlayerSwitchFlashlight(client, isEnabled)
     if not client:getChar() then return false end
+    if hook.Run("PrePlayerToggleFlashlight", client, isEnabled) == false then return false end
     if hook.Run("CanPlayerToggleFlashlight", client, isEnabled) == false then return false end
     local enabled, needsItem, cooldown = lia.config.get("FlashlightEnabled", true), lia.config.get("FlashlightNeedsItem", true), lia.config.get("FlashlightCooldown", 0.5)
     if not enabled or (client.FlashlightCooldown or 0) >= CurTime() then return false end

--- a/freelook/docs/hooks.md
+++ b/freelook/docs/hooks.md
@@ -20,6 +20,12 @@ Return `false` to disable freelook for the player.
 **Parameters**
 - `client` (`Player`): Local player.
 
+### PreFreelookToggle
+Called before freelook mode is toggled.
+
+**Parameters**
+- `state` (`boolean`): Desired enabled state.
+
 ### FreelookToggled
 Triggered when freelook mode is toggled via the console command.
 

--- a/freelook/libraries/client.lua
+++ b/freelook/libraries/client.lua
@@ -71,10 +71,12 @@ function MODULE:SetupQuickMenu(menu)
 end
 
 concommand.Add("+freelook", function()
+    if hook.Run("PreFreelookToggle", true) == false then return end
     freelooking = true
     hook.Run("FreelookToggled", true)
 end)
 concommand.Add("-freelook", function()
+    if hook.Run("PreFreelookToggle", false) == false then return end
     freelooking = false
     hook.Run("FreelookToggled", false)
 end)


### PR DESCRIPTION
## Summary
- hook when players close description windows or start editing
- allow hooking before description data updates on the server
- expose pre/post hooks around first person effect calculations
- run a pre-hook before flashlight toggles
- add hooks before freelook toggles
- document all new hooks

## Testing
- `apt-get update` *(fails: repository signatures can't be verified due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6874d2516c78832795b5165450b23c23