### PR TITLE
Add pre hooks to modules

### DIFF
--- a/gamemasterpoints/libraries/server.lua
+++ b/gamemasterpoints/libraries/server.lua
@@ -5,6 +5,7 @@ function MODULE:LoadData()
 end
 
 function MODULE:AddPoint(client, name, pos)
+    hook.Run("GamemasterPreAddPoint", client, name, pos)
     if not name or not pos then
         client:notifyLocalized("invalidInfo")
         return
@@ -23,6 +24,7 @@ function MODULE:AddPoint(client, name, pos)
 end
 
 function MODULE:RemovePoint(client, name)
+    hook.Run("GamemasterPreRemovePoint", client, name)
     if not name then
         client:notifyLocalized("invalidInfo")
         return
@@ -57,6 +59,7 @@ function MODULE:RemovePoint(client, name)
 end
 
 function MODULE:RenamePoint(client, name, newName)
+    hook.Run("GamemasterPreRenamePoint", client, name, newName)
     if not name or not newName then
         client:notifyLocalized("invalidInfo")
         return
@@ -92,6 +95,7 @@ function MODULE:RenamePoint(client, name, newName)
 end
 
 function MODULE:UpdateSound(client, name, _, newSound)
+    hook.Run("GamemasterPreUpdateSound", client, name, newSound)
     if not name or not newSound then
         client:notifyLocalized("invalidInfo")
         return
@@ -117,6 +121,7 @@ function MODULE:UpdateSound(client, name, _, newSound)
 end
 
 function MODULE:UpdateEffect(client, name, _, newEffect)
+    hook.Run("GamemasterPreUpdateEffect", client, name, newEffect)
     if not name or not newEffect then
         client:notifyLocalized("invalidInfo")
         return
@@ -142,6 +147,7 @@ function MODULE:UpdateEffect(client, name, _, newEffect)
 end
 
 function MODULE:MoveToPoint(client, name)
+    hook.Run("GamemasterPreMoveToPoint", client, name)
     if not name then
         client:notifyLocalized("invalidInfo")
         return

--- a/hud_extras/libraries/client.lua
+++ b/hud_extras/libraries/client.lua
@@ -3,6 +3,7 @@ local vignetteAlphaGoal, vignetteAlphaDelta = 0, 0
 local hasVignetteMaterial = lia.util.getMaterial("lilia/gui/vignette.png") ~= "___error"
 local mathApproach = math.Approach
 local function DrawFPS()
+    hook.Run("HUDExtrasPreDrawFPS")
     local fpsFont = lia.config.get("FPSHudFont")
     local f = math.Round(1 / FrameTime())
     local minF = MODULE.minFPS or 60
@@ -32,6 +33,7 @@ end, {
 
 local function DrawVignette()
     if hasVignetteMaterial then
+        hook.Run("HUDExtrasPreDrawVignette")
         local ft = FrameTime()
         local w, h = ScrW(), ScrH()
         vignetteAlphaDelta = mathApproach(vignetteAlphaDelta, vignetteAlphaGoal, ft * 30)
@@ -44,6 +46,7 @@ end
 
 local function DrawBlur()
     local client = LocalPlayer()
+    hook.Run("HUDExtrasPreDrawBlur")
     blurGoal = client:getLocalVar("blur", 0) + (hook.Run("AdjustBlurAmount", blurGoal) or 0)
     if blurValue ~= blurGoal then blurValue = mathApproach(blurValue, blurGoal, FrameTime() * 20) end
     if blurValue > 0 and not client:ShouldDrawLocalPlayer() then lia.util.drawBlurAt(0, 0, ScrW(), ScrH(), blurValue) end
@@ -63,6 +66,7 @@ local function canDrawWatermark()
 end
 
 local function drawWatermark()
+    hook.Run("HUDExtrasPreDrawWatermark")
     local w, h = 64, 64
     local logoPath = lia.config.get("WatermarkLogo", "")
     local ver = tostring(lia.config.get("GamemodeVersion", ""))

--- a/instakill/libraries/server.lua
+++ b/instakill/libraries/server.lua
@@ -1,5 +1,6 @@
 function MODULE:ScalePlayerDamage(client, hitgroup, dmgInfo)
     if lia.config.get("instakilling") and hitgroup == HITGROUP_HEAD then
+        hook.Run("PlayerPreInstantKill", client, dmgInfo)
         dmgInfo:SetDamage(client:GetMaxHealth() * 5)
         hook.Run("PlayerInstantKilled", client, dmgInfo)
     end

--- a/inventory/libraries/server.lua
+++ b/inventory/libraries/server.lua
@@ -1,4 +1,5 @@
 ﻿function MODULE:PlayerLoadedChar(client, character)
+    hook.Run("InventoryPrePlayerLoadedChar", client, character)
     local inv = character:getInv()
     if inv then
         local baseMax = lia.config.get("invMaxWeight")
@@ -10,6 +11,7 @@
             inv:sync(client)
         end
     end
+    hook.Run("InventoryPostPlayerLoadedChar", client, character, inv)
 end
 
 local networkStrings = {"liaStorageOpen", "liaStorageUnlock", "liaStorageExit", "liaStorageTransfer", "trunkInitStorage", "VendorTrade", "VendorExit", "VendorMoney", "VendorStock", "VendorMaxStock", "VendorAllowFaction", "VendorAllowClass", "VendorEdit", "VendorMode", "VendorPrice", "VendorSync", "VendorOpen"}

--- a/inventory/weightinv.lua
+++ b/inventory/weightinv.lua
@@ -110,6 +110,7 @@ if SERVER then
         local canAccess, reason = self:canAccess("add", context)
         if not canAccess then return d:reject(reason or "noAccess") end
         if justAddDirectly then
+            hook.Run("PreWeightInvItemAdded", self, item)
             self:addItem(item)
             hook.Run("WeightInvItemAdded", self, item)
             return d:resolve(item)
@@ -119,6 +120,7 @@ if SERVER then
         local itemType = item.uniqueID
         for _ = 1, quantity do
             lia.item.instance(self:getID(), itemType, nil, 0, 0, function(newItem)
+                hook.Run("PreWeightInvItemAdded", self, newItem)
                 self:addItem(newItem)
                 items[#items + 1] = newItem
                 hook.Run("WeightInvItemAdded", self, newItem)
@@ -135,11 +137,13 @@ if SERVER then
         if quantity <= 0 then return d:reject("quantity must be positive") end
         if isnumber(itemTypeOrID) then
             local item = self.items[itemTypeOrID]
+            if item then hook.Run("PreWeightInvItemRemoved", self, item) end
             self:removeItem(itemTypeOrID)
             if item then hook.Run("WeightInvItemRemoved", self, item) end
         else
             local items = self:getItemsOfType(itemTypeOrID)
             for i = 1, math.min(quantity, #items) do
+                hook.Run("PreWeightInvItemRemoved", self, items[i])
                 self:removeItem(items[i]:getID())
                 hook.Run("WeightInvItemRemoved", self, items[i])
             end
@@ -157,6 +161,7 @@ if SERVER then
 
         for _, id in pairs(ids) do
             local item = self.items[id]
+            if item then hook.Run("PreWeightInvItemRemoved", self, item) end
             self:removeItem(id)
             if item then hook.Run("WeightInvItemRemoved", self, item) end
         end

--- a/joinleavemessages/libraries/server.lua
+++ b/joinleavemessages/libraries/server.lua
@@ -1,5 +1,6 @@
 function MODULE:PlayerDisconnected(client)
     local message = L("playerLeft", client:Nick())
+    hook.Run("PreJoinLeaveMessageSent", client, false, message)
     for _, ply in player.Iterator() do
         ClientAddText(ply, Color(255, 0, 0), message)
     end
@@ -8,6 +9,7 @@ end
 
 function MODULE:PlayerInitialSpawn(client)
     local message = L("playerJoined", client:Nick())
+    hook.Run("PreJoinLeaveMessageSent", client, true, message)
     for _, ply in player.Iterator() do
         ClientAddText(ply, Color(0, 255, 0), message)
     end


### PR DESCRIPTION
## Summary
- add pre hooks to Gamemaster Points module
- add pre draw hooks in HUD Extras
- add PrePlayerInstantKill hook
- add inventory pre/post hooks
- add pre add/remove hooks in Weight Inv
- add pre hook for join/leave messages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874d25551c88327923669a2f3a94d74