### PR TITLE
Add more hooks for module actions

### DIFF
--- a/loadmessages/libraries/server.lua
+++ b/loadmessages/libraries/server.lua
@@ -1,7 +1,11 @@
-﻿function MODULE:PlayerLoadedChar(client)
+function MODULE:PlayerLoadedChar(client)
     local data = self.FactionMessages[client:Team()]
     if data then
+        hook.Run("PreLoadMessage", client, data)
         ClientAddText(client, unpack(data))
         hook.Run("LoadMessageSent", client, data)
+        hook.Run("PostLoadMessage", client, data)
+    else
+        hook.Run("LoadMessageMissing", client)
     end
 end

--- a/loyalism/libraries/server.lua
+++ b/loyalism/libraries/server.lua
@@ -1,15 +1,20 @@
-﻿local MODULE = MODULE
+local MODULE = MODULE
 function MODULE:PlayerLoadedChar()
     self:UpdatePartyTiers()
 end
 
 function MODULE:UpdatePartyTiers()
+    hook.Run("PreUpdatePartyTiers")
     for _, ply in player.Iterator() do
         local char = ply:getChar()
         if char then
             local tier = char:getData("party_tier", 0)
+            hook.Run("PartyTierApplying", ply, tier)
             char:setData("party_tier", tier, false, player.GetAll())
             hook.Run("PartyTierUpdated", ply, tier)
+        else
+            hook.Run("PartyTierNoCharacter", ply)
         end
     end
+    hook.Run("PostUpdatePartyTiers")
 end

--- a/mapcleaner/libraries/server.lua
+++ b/mapcleaner/libraries/server.lua
@@ -1,17 +1,21 @@
-﻿function MODULE:InitializedModules()
+function MODULE:InitializedModules()
     if not lia.config.get("MapCleanerEnabled", true) then return end
     local itemCleanupTime = lia.config.get("ItemCleanupTime", 7200)
     local mapCleanupTime = lia.config.get("MapCleanupTime", 21600)
     timer.Create("clearWorldItemsWarning", itemCleanupTime - 60, 0, function()
+        hook.Run("PreItemCleanupWarning")
         for _, client in player.Iterator() do
             client:ChatPrint(L("itemCleanupWarning"))
         end
+        hook.Run("PostItemCleanupWarning")
     end)
 
     timer.Create("AutomaticMapCleanupWarning", mapCleanupTime - 60, 0, function()
+        hook.Run("PreMapCleanupWarning")
         for _, client in player.Iterator() do
             client:ChatPrint(L("mapCleanupWarning"))
         end
+        hook.Run("PostMapCleanupWarning")
     end)
 
     timer.Create("clearWorldItems", itemCleanupTime, 0, function()
@@ -21,6 +25,7 @@
         end
 
         for _, item in pairs(ents.FindByClass("lia_item")) do
+            hook.Run("ItemCleanupEntityRemoved", item)
             item:Remove()
         end
         hook.Run("PostItemCleanup")
@@ -33,7 +38,10 @@
         end
 
         for _, ent in ents.Iterator() do
-            if table.HasValue(self.MapCleanerEntitiesToRemove, ent:GetClass()) then ent:Remove() end
+            if table.HasValue(self.MapCleanerEntitiesToRemove, ent:GetClass()) then
+                hook.Run("MapCleanupEntityRemoved", ent)
+                ent:Remove()
+            end
         end
         hook.Run("PostMapCleanup")
     end)

--- a/modelpay/libraries/server.lua
+++ b/modelpay/libraries/server.lua
@@ -1,16 +1,19 @@
-﻿local ModelPay = {
+local ModelPay = {
     ["models/player/barney.mdl"] = 25,
 }
 
 function MODULE:GetSalaryAmount(client)
     if not IsValid(client) or not client:getChar() then return 0 end
     local playerModel = string.lower(client:GetModel())
+    hook.Run("ModelPayModelChecked", client, playerModel)
     for model, pay in pairs(ModelPay) do
         if model:lower() == playerModel then
+            hook.Run("ModelPayModelMatched", client, model, pay)
             hook.Run("ModelPaySalaryDetermined", client, pay)
             return pay
         end
     end
+    hook.Run("ModelPayModelNotMatched", client, playerModel)
     hook.Run("ModelPaySalaryDetermined", client, 0)
     return 0
 end
@@ -19,5 +22,7 @@ function MODULE:PlayerModelChanged(client, newModel)
     if ModelPay[newModel] then
         hook.Run("CreateSalaryTimer", client)
         hook.Run("ModelPayModelEligible", client, newModel)
+    else
+        hook.Run("ModelPayModelIneligible", client, newModel)
     end
 end

--- a/modeltweaker/libraries/server.lua
+++ b/modeltweaker/libraries/server.lua
@@ -1,6 +1,7 @@
-﻿local MODULE = MODULE
+local MODULE = MODULE
 net.Receive("WardrobeChangeModel", function(_, client)
     local newModel = net.ReadString()
+    hook.Run("WardrobeModelChangeRequested", client, newModel)
     local char = client:getChar()
     if not char then return end
     local faction = char:getFaction()
@@ -14,10 +15,12 @@ net.Receive("WardrobeChangeModel", function(_, client)
     end
 
     if isValid then
+        hook.Run("PreWardrobeModelChange", client, newModel)
         char:setModel(newModel)
         client:SetModel(newModel)
         client:notifyLocalized("wardrobeModelChanged")
         hook.Run("WardrobeModelChanged", client, newModel)
+        hook.Run("PostWardrobeModelChange", client, newModel)
     else
         client:notifyLocalized("wardrobeModelInvalid")
         hook.Run("WardrobeModelInvalid", client, newModel)

--- a/npcdrop/libraries/server.lua
+++ b/npcdrop/libraries/server.lua
@@ -1,15 +1,21 @@
-﻿local MODULE = MODULE
+local MODULE = MODULE
 function MODULE:OnNPCKilled(ent)
     if not ent:IsNPC() then return end
+    hook.Run("NPCDropCheck", ent)
     local weights = self.DropTable[ent:GetClass()]
-    if not weights then return end
+    if not weights then
+        hook.Run("NPCDropNoTable", ent)
+        return end
     local totalWeight = 0
     for _, w in pairs(weights) do
         if isnumber(w) and w > 0 then totalWeight = totalWeight + w end
     end
 
-    if totalWeight <= 0 then return end
+    if totalWeight <= 0 then
+        hook.Run("NPCDropNoItems", ent)
+        return end
     local choice = math.random(totalWeight)
+    hook.Run("NPCDropRoll", ent, choice, totalWeight)
     for itemName, weight in pairs(weights) do
         if choice <= weight then
             lia.item.spawn(itemName, ent:GetPos() + Vector(0, 0, 16), nil, ent:GetAngles())
@@ -19,4 +25,5 @@ function MODULE:OnNPCKilled(ent)
 
         choice = choice - weight
     end
+    hook.Run("NPCDropFailed", ent)
 end


### PR DESCRIPTION
## Summary
- add pre/post message hooks in loadmessages
- extend loyalism tier update hooks
- hook into map cleaner warnings and entity removal
- report model pay checks and eligibility updates
- emit wardrobe change events in modeltweaker
- provide more NPC drop events

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874d25971248327afa424a6edd4e73e