### PR TITLE
Add action hooks

### DIFF
--- a/realisticview/docs/hooks.md
+++ b/realisticview/docs/hooks.md
@@ -12,6 +12,23 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### ShouldUseRealisticView
+Return `false` to disable the camera effect for the player.
+
+**Parameters**
+- `player` (`Player`): Player being processed.
+
+### RealisticViewUpdated
+Called clientside after the camera table is built.
+
+**Parameters**
+- `player` (`Player`): The local player.
+- `view` (`table`): View data table.
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/realisticview/libraries/client.lua
+++ b/realisticview/libraries/client.lua
@@ -1,5 +1,6 @@
 ﻿function MODULE:CalcView(client, origin, angles)
     if not client:InVehicle() and lia.option.get("realisticViewEnabled") then
+        if hook.Run("ShouldUseRealisticView", client) == false then return end
         local view = {
             origin = origin,
             angles = angles,
@@ -32,6 +33,7 @@
             view.angles = Angle(head.Ang.p, head.Ang.y, angles.r)
         end
 
+        hook.Run("RealisticViewUpdated", client, view)
         hook.Run("RealisticViewCalcView", client, view)
         return view
       end

--- a/rumour/commands.lua
+++ b/rumour/commands.lua
@@ -15,12 +15,16 @@
             return
         end
 
+        if hook.Run("CanSendRumour", client, rumourMessage) == false then return end
+
         if not client.rumourdelay then client.rumourdelay = 0 end
         if CurTime() < client.rumourdelay then
             local seconds = math.ceil(client.rumourdelay - CurTime())
             client:notifyLocalized("commandCooldownTimed", seconds)
             return
         end
+
+        hook.Run("RumourAttempt", client, rumourMessage)
 
         client.rumourdelay = CurTime() + lia.config.get("RumourCooldown", 60)
         local revealChance = lia.config.get("RumourRevealChance", 0.02)

--- a/rumour/docs/hooks.md
+++ b/rumour/docs/hooks.md
@@ -12,6 +12,32 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### CanSendRumour
+Return `false` to block the player from sending the rumour.
+
+**Parameters**
+- `player` (`Player`): Player attempting to send a rumour.
+- `text` (`string`): Rumour contents.
+
+### RumourAttempt
+Called when a rumour passes basic checks and is about to be broadcast.
+
+**Parameters**
+- `player` (`Player`): Player sending the rumour.
+- `text` (`string`): Rumour contents.
+
+### RumourSent
+Triggered after the rumour has been sent to recipients.
+
+**Parameters**
+- `player` (`Player`): Sender of the rumour.
+- `text` (`string`): Rumour contents.
+- `revealed` (`boolean`): Whether the sender was revealed.
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/shootlock/docs/hooks.md
+++ b/shootlock/docs/hooks.md
@@ -12,6 +12,40 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### LockShotAttempt
+Runs when a player fires at a door lock.
+
+**Parameters**
+- `player` (`Player`): Shooter.
+- `door` (`Entity`): Door being targeted.
+- `dmg` (`CTakeDamageInfo`): Damage info object.
+
+### LockShotSuccess
+Called when the shot successfully breaches the lock.
+
+**Parameters**
+- `player` (`Player`): Shooter.
+- `door` (`Entity`): Door opened.
+
+### LockShotFailed
+Triggered when a shot hits the lock but fails to breach it.
+
+**Parameters**
+- `player` (`Player`): Shooter.
+- `door` (`Entity`): Target door.
+- `dmg` (`CTakeDamageInfo`): Damage info object.
+
+### LockShotBreach
+Fired after the door forcibly opens from a shot.
+
+**Parameters**
+- `player` (`Player`): Shooter.
+- `door` (`Entity`): Door opened.
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/shootlock/libraries/server.lua
+++ b/shootlock/libraries/server.lua
@@ -4,6 +4,7 @@
         if handle and dmgInfo:IsBulletDamage() then
             local client = dmgInfo:GetAttacker()
             local position = dmgInfo:GetDamagePosition()
+            hook.Run("LockShotAttempt", client, entity, dmgInfo)
             if client:GetEyeTrace().Entity ~= entity or client:GetPos():Distance(position) > 100 then return end
             if IsValid(client) then
                 if hook.Run("CanPlayerBustLock", client, entity) == false then return end
@@ -17,6 +18,7 @@
                     effect:SetScale(10)
                     util.Effect("GlassImpact", effect, true, true)
                     hook.Run("LockShotBreach", client, entity)
+                    hook.Run("LockShotSuccess", client, entity)
                     return
                 end
             end
@@ -36,9 +38,11 @@
                 entity:Fire("openawayfrom", name)
                 entity:EmitSound("physics/wood/wood_plank_break" .. math.random(1, 4) .. ".wav", 100, 120)
                 hook.Run("LockShotBreach", client, entity)
+                hook.Run("LockShotSuccess", client, entity)
                 entity.liaNextBreach = CurTime() + 1
                 timer.Simple(0.5, function() if IsValid(entity) then entity:Fire("setspeed", entity.liaOldSpeed) end end)
             end
+            hook.Run("LockShotFailed", client, entity, dmgInfo)
         end
     end
 end

--- a/simple_lockpicking/docs/hooks.md
+++ b/simple_lockpicking/docs/hooks.md
@@ -12,6 +12,46 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### CanPlayerLockpick
+Return `false` to prevent a player from starting to lockpick.
+
+**Parameters**
+- `player` (`Player`): Player attempting the action.
+- `target` (`Entity`): Door or vehicle being lockpicked.
+
+### LockpickStart
+Triggered when a lockpick attempt begins.
+
+**Parameters**
+- `player` (`Player`): Player lockpicking.
+- `target` (`Entity`): Door or vehicle.
+
+### LockpickSuccess
+Called when the lockpick finishes successfully.
+
+**Parameters**
+- `player` (`Player`): Player lockpicking.
+- `target` (`Entity`): Unlocked entity.
+
+### LockpickInterrupted
+Fired when the attempt is cancelled before completion.
+
+**Parameters**
+- `player` (`Player`): Player lockpicking.
+- `target` (`Entity`): Target entity.
+
+### LockpickFinished
+Runs after an attempt ends for any reason.
+
+**Parameters**
+- `player` (`Player`): Player lockpicking.
+- `target` (`Entity`): Target entity.
+- `success` (`boolean`): Whether the pick succeeded.
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/simple_lockpicking/items/lockpick.lua
+++ b/simple_lockpicking/items/lockpick.lua
@@ -9,6 +9,7 @@ ITEM.functions.Use = {
         local ply = item.player
         local target = ply:GetEyeTrace().Entity
         if not ply:getNetVar("restricted") and IsValid(target) or target:IsVehicle() and target:isLocked() then
+            if hook.Run("CanPlayerLockpick", ply, target) == false then return false end
             item.beingUsed = true
             hook.Run("LockpickStart", ply, target)
             local timerID = "Lockpicksnd" .. ply:SteamID()
@@ -32,12 +33,14 @@ ITEM.functions.Use = {
                 ply:setNetVar("isPicking")
                 timer.Remove(timerID)
                 hook.Run("LockpickSuccess", ply, target)
+                hook.Run("LockpickFinished", ply, target, true)
             end, 15, function()
                 ply:setNetVar("isPicking")
                 ply:setAction()
                 item.beingUsed = false
                 timer.Remove(timerID)
                 hook.Run("LockpickInterrupted", ply, target)
+                hook.Run("LockpickFinished", ply, target, false)
             end)
         else
             item.player:notifyLocalized("targetUnlocked")

--- a/slots/docs/hooks.md
+++ b/slots/docs/hooks.md
@@ -12,6 +12,40 @@ If multiple definitions of the same hook exist on `GM`, `MODULE`, or `SCHEMA`, t
 
 ---
 
+## Module Hooks
+
+### SlotMachineUse
+Runs when a player presses use on the machine before paying.
+
+**Parameters**
+- `machine` (`Entity`): The slot machine.
+- `player` (`Player`): Player using the machine.
+
+### SlotMachineStart
+Called right after payment is taken and the wheels begin spinning.
+
+**Parameters**
+- `machine` (`Entity`): The slot machine.
+- `player` (`Player`): Player using the machine.
+
+### SlotMachinePayout
+Triggered when the player wins money from the machine.
+
+**Parameters**
+- `machine` (`Entity`): The slot machine.
+- `player` (`Player`): Winner.
+- `amount` (`number`): Winnings.
+
+### SlotMachineEnd
+Runs after the wheels stop regardless of payout.
+
+**Parameters**
+- `machine` (`Entity`): The slot machine.
+- `player` (`Player`): Player who used it.
+- `amount` (`number`): Final payout.
+
+---
+
 ## Overview
 
 Gamemode hooks fire at various stages during play and let you modify global behavior. They can be called from your schema with `SCHEMA:HookName`, from modules using `MODULE:HookName`, or via `hook.Add`. When the same hook is defined in more than one place, whichever version loads last takes effect. All hooks are optional; if no handler is present, the default logic runs.

--- a/slots/entities/entities/slot_machine/init.lua
+++ b/slots/entities/entities/slot_machine/init.lua
@@ -63,6 +63,8 @@ function ENT:Use(client)
         return
     end
 
+    hook.Run("SlotMachineUse", self, client)
+
     timer.Create("SpinWheels" .. self:EntIndex(), 0, 1, function()
         self.IsPlaying = false
         character:takeMoney(MODULE.GamblingPrice)
@@ -134,6 +136,7 @@ function ENT:Use(client)
 
             self.IsPlaying = true
             self.Jackpot = false
+            hook.Run("SlotMachineEnd", self, client, payout)
         end)
     end)
 end


### PR DESCRIPTION
## Summary
- add pre/post hooks for Realistic View
- allow hooking when sending rumours
- trigger hooks when shooting locks
- extend lockpick item events
- add slot machine usage hooks
- document all new hooks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874d261f1388327843a857b5c0b257d