### PR TITLE
Add extra hooks for module actions

### DIFF
--- a/slowweapons/docs/hooks.md
+++ b/slowweapons/docs/hooks.md
@@ -45,6 +45,21 @@ Fires when slowdown is applied so other modules can react.
 **Returns**
 - None
 
+### PostApplyWeaponSlowdown
+
+**Purpose**
+Runs after the max speed has been set.
+
+**Parameters**
+
+- `client` (`Player`): Player being slowed.
+- `weapon` (`Weapon`): Active weapon.
+- `moveData` (`CMoveData`): Current move data.
+- `speed` (`number`): Calculated max speed.
+
+**Returns**
+- None
+
 
 ## Overview
 

--- a/slowweapons/libraries/server.lua
+++ b/slowweapons/libraries/server.lua
@@ -10,4 +10,5 @@
     hook.Run("ApplyWeaponSlowdown", client, wep, moveData, speed)
     moveData:SetMaxSpeed(speed)
     moveData:SetMaxClientSpeed(speed)
+    hook.Run("PostApplyWeaponSlowdown", client, wep, moveData, speed)
 end

--- a/stungun/docs/hooks.md
+++ b/stungun/docs/hooks.md
@@ -90,6 +90,33 @@ Runs when a rope tether is attached between the user and the target.
 **Returns**
 - None
 
+### StunGunReloaded
+
+**Purpose**
+Triggered when a reload finishes and power is restored.
+
+**Parameters**
+
+- `player` (`Player`): Player reloading the weapon.
+- `weapon` (`Weapon`): Stungun weapon.
+
+**Returns**
+- None
+
+### StunGunLaserToggled
+
+**Purpose**
+Runs when the laser sight is toggled on or off.
+
+**Parameters**
+
+- `player` (`Player`): Owner of the weapon.
+- `state` (`boolean`): New laser state.
+- `weapon` (`Weapon`): Stungun weapon.
+
+**Returns**
+- None
+
 ---
 
 ## Overview

--- a/stungun/entities/weapons/weapon_stungun.lua
+++ b/stungun/entities/weapons/weapon_stungun.lua
@@ -212,6 +212,7 @@ function SWEP:Reload()
         self.Reloading = false
         self.Power = 100
         self:SetNW2Int("power", self.Power)
+        hook.Run("StunGunReloaded", self:GetOwner(), self)
     end)
 end
 
@@ -231,6 +232,7 @@ function SWEP:SecondaryAttack()
             net.WriteEntity(self)
             net.WriteBit(self.Laser)
             net.Broadcast()
+            hook.Run("StunGunLaserToggled", owner, self.Laser, self)
         end)
     end
 end

--- a/tying/docs/hooks.md
+++ b/tying/docs/hooks.md
@@ -25,6 +25,20 @@ Called after a player is fully restrained with handcuffs.
 
 ---
 
+### PlayerStartHandcuff
+
+**Purpose**
+Triggered just before a player is cuffed.
+
+**Parameters**
+
+- `target` (`Player`): The player being cuffed.
+
+**Returns**
+- None
+
+---
+
 ### PlayerUnhandcuffed
 
 **Purpose**
@@ -33,6 +47,46 @@ Fires once handcuffs are removed.
 **Parameters**
 
 - `target` (`Player`): The player released from cuffs.
+
+**Returns**
+- None
+---
+
+### PlayerStartUnTying
+
+**Purpose**
+Runs when an attempt to untie a player begins.
+
+**Parameters**
+
+- `actor` (`Player`): The player starting the action.
+- `target` (`Player`): The cuffed player.
+
+**Returns**
+- None
+
+### PlayerFinishUnTying
+
+**Purpose**
+Triggered after the untie sequence completes successfully.
+
+**Parameters**
+
+- `actor` (`Player`): The player who untied.
+- `target` (`Player`): The freed player.
+
+**Returns**
+- None
+
+### PlayerUnTieAborted
+
+**Purpose**
+Fires if the untie action is canceled for any reason.
+
+**Parameters**
+
+- `actor` (`Player`): The player canceling the action.
+- `target` (`Player`): The cuffed player.
 
 **Returns**
 - None

--- a/tying/libraries/server.lua
+++ b/tying/libraries/server.lua
@@ -46,16 +46,19 @@ function MODULE:PlayerUse(client, entity)
     if client:IsHandcuffed() then return false end
     if entity:IsPlayer() and entity:IsHandcuffed() and not entity.liaBeingUnTied then
         entity.liaBeingUnTied = true
+        hook.Run("PlayerStartUnTying", client, entity)
         entity:setAction(L("beingUntied"), 5)
         client:setAction(L("untying"), 5)
         client:doStaredAction(entity, function()
             OnHandcuffRemove(entity)
             entity.liaBeingUnTied = false
+            hook.Run("PlayerFinishUnTying", client, entity)
             client:EmitSound("npc/roller/blade_in.wav")
         end, 5, function()
             entity.liaBeingUnTied = false
             entity:stopAction()
             client:stopAction()
+            hook.Run("PlayerUnTieAborted", client, entity)
         end)
     end
 end
@@ -74,6 +77,7 @@ end
 
 function HandcuffPlayer(target)
     if not IsValid(target) then return end
+    hook.Run("PlayerStartHandcuff", target)
     for _, v in pairs(target:getChar():getInv():getItems()) do
         if v.isWeapon and v:getData("equip") then v:setData("equip", nil) end
     end

--- a/viewbob/docs/hooks.md
+++ b/viewbob/docs/hooks.md
@@ -29,6 +29,19 @@ Triggered before view punch angles are applied so you can modify them.
 **Returns**
 - None
 
+### ViewBobStep
+
+**Purpose**
+Allows modifying the step direction used for view bobbing.
+
+**Parameters**
+
+- `player` (`Player`): Local player stepping.
+- `step` (`number`): Value of `1` or `-1` for the current step.
+
+**Returns**
+- `number` (optional): New step value.
+
 ---
 
 ## Overview

--- a/viewbob/libraries/client.lua
+++ b/viewbob/libraries/client.lua
@@ -11,6 +11,8 @@ function MODULE:PlayerFootstep(client)
     local multiplier_crouch = lia.option.get("viewbobMultiplierCrouch") or 0.1
     local multiplier_sprint = lia.option.get("viewbobMultiplierSprint") or 0.4
     stepvalue = stepvalue == 0 and 1 or -1
+    local override = hook.Run("ViewBobStep", client, stepvalue)
+    if isnumber(override) then stepvalue = override end
     if client:KeyDown(IN_DUCK) then
         if client:KeyDown(IN_FORWARD) then
             applyViewPunch(client, 1.5 * multiplier_crouch, stepvalue * 0.75 * multiplier_crouch, stepvalue * 0.75 * multiplier_crouch)

--- a/vmanip/docs/hooks.md
+++ b/vmanip/docs/hooks.md
@@ -24,6 +24,16 @@ Called on the server when a player picks up an item and the pickup animation is 
 - `player` (`Player`): Player picking up the item.
 - `item` (`Item`): Item being taken.
 
+### PreVManipPickup
+
+**Purpose**
+Runs on the server before the pickup animation network message is sent.
+
+**Parameters**
+
+- `player` (`Player`): Player picking up the item.
+- `item` (`Item`): Item being taken.
+
 ---
 
 ### VManipAnimationPlayed
@@ -37,6 +47,18 @@ Fires on the client after the pickup animation plays.
 
 **Returns**
 - None
+
+### VManipChooseAnim
+
+**Purpose**
+Allows selecting a custom animation to play for an item pickup.
+
+**Parameters**
+
+- `itemID` (`string`): Identifier of the item that triggered the animation.
+
+**Returns**
+- `string` (optional): Animation name to use.
 
 ---
 

--- a/vmanip/libraries/server.lua
+++ b/vmanip/libraries/server.lua
@@ -1,6 +1,7 @@
 ﻿function MODULE:OnPlayerInteractItem(client, action, item)
     local isDisabled = item.VManipDisabled
     if action == "take" and not isDisabled then
+        hook.Run("PreVManipPickup", client, item)
         net.Start("PlayPickupAnimation")
         net.WriteString(item.uniqueID)
         net.Send(client)

--- a/vmanip/netcalls/client.lua
+++ b/vmanip/netcalls/client.lua
@@ -4,7 +4,8 @@
     local item = lia.item.list[itemID]
     local isDisabled = item.VManipDisabled
     if item and VManip.PlayAnim and not isDisabled then
-        VManip:PlayAnim("interactslower")
+        local anim = hook.Run("VManipChooseAnim", itemID) or "interactslower"
+        VManip:PlayAnim(anim)
         hook.Run("VManipAnimationPlayed", itemID)
     end
 end)

--- a/warrants/docs/hooks.md
+++ b/warrants/docs/hooks.md
@@ -28,6 +28,34 @@ Called whenever a player's warrant state toggles on or off.
 **Returns**
 - None
 
+### PreWarrantToggle
+
+**Purpose**
+Called right before a warrant state is changed.
+
+**Parameters**
+
+- `character` (`Character`): Character whose status will change.
+- `warranter` (`Player`): Player issuing or removing the warrant.
+- `state` (`boolean`): New status that will be set.
+
+**Returns**
+- None
+
+### PostWarrantToggle
+
+**Purpose**
+Fires after the warrant change has been processed.
+
+**Parameters**
+
+- `character` (`Character`): Character whose status changed.
+- `warranter` (`Player`): Player issuing or removing the warrant.
+- `state` (`boolean`): New status value.
+
+**Returns**
+- None
+
 ---
 
 ## Overview

--- a/warrants/meta/sh_player.lua
+++ b/warrants/meta/sh_player.lua
@@ -2,6 +2,7 @@
 if SERVER then
     function characterMeta:ToggleWanted(warranter)
         local warranted = not self:IsWanted()
+        hook.Run("PreWarrantToggle", self, warranter, warranted)
         self:setData("wanted", warranted)
         hook.Run("WarrantStatusChanged", self, warranter, warranted)
         local notificationMessage = warranted and L("WarrantIssued") or L("WarrantRemoved")
@@ -19,6 +20,7 @@ if SERVER then
                 ply:notify(string.format(expirationText, description, warranted and L("issued") or L("expired")))
             end
         end
+        hook.Run("PostWarrantToggle", self, warranter, warranted)
     end
 
     function characterMeta:CanWarrantPlayers()


### PR DESCRIPTION
## Summary
- fire `PostApplyWeaponSlowdown` when heavy weapon slowdowns finalize
- add reload and laser hooks to StunGun
- expose start/cancel hooks for handcuffing and untying
- allow modifying viewbob step behavior
- provide vmanip hooks before pickup and for custom animations
- trigger pre/post events when toggling warrants

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d265d32c8327ae07c701474dd468