### PR TITLE
Add extra hooks

### DIFF
--- a/compass/docs/hooks.md
+++ b/compass/docs/hooks.md
@@ -54,6 +54,15 @@ end)
 
 ---
 
+### Additional Hooks
+
+- `PreCompassMarkerAdded` (`Server`)
+  Called before a new position marker is inserted.
+- `PreCompassEntityMarkerAdded` (`Server`)
+  Called before a new entity marker is inserted.
+- `CompassSpotCommand` (`Server`)
+  Fired when a player runs the `mcompass_spot` console command.
+
 ### WebImageDownloaded
 
 **Purpose**
@@ -80,3 +89,12 @@ end)
 
 ---
 
+
+### Additional Hooks
+
+- `PreCompassMarkerAdded` (`Server`)
+  Called before a new position marker is inserted.
+- `PreCompassEntityMarkerAdded` (`Server`)
+  Called before a new entity marker is inserted.
+- `CompassSpotCommand` (`Server`)
+  Fired when a player runs the `mcompass_spot` console command.

--- a/compass/libraries/shared.lua
+++ b/compass/libraries/shared.lua
@@ -55,6 +55,7 @@ if SERVER then
     util.AddNetworkString("mCompass_RemoveMarker")
     local mCompass_MarkerTable = mCompass_MarkerTable or {}
     function MODULE.AddMarker(ply, pos, players, time, color, icon, name)
+        hook.Run("PreCompassMarkerAdded", ply, pos, players, time, color, icon, name)
         name = name or ""
         icon = icon or ""
         color = color or mCompass_Settings.Spotted_Enemy_Color
@@ -90,6 +91,7 @@ if SERVER then
     end
 
     function MODULE.AddEntityMarker(ply, ent, players, time, color, icon, name)
+        hook.Run("PreCompassEntityMarkerAdded", ply, ent, players, time, color, icon, name)
         name = name or ""
         icon = icon or ""
         color = color or mCompass_Settings.Spotted_Enemy_Color
@@ -155,6 +157,8 @@ if SERVER then
             endpos = ply:EyePos() + ply:EyeAngles():Forward() * mCompass_Settings.Max_Spot_Distance,
             filter = ply
         })
+
+        hook.Run("CompassSpotCommand", ply, tr)
 
         local t = CurTime() + mCompass_Settings.Spot_Duration
         if tr.Entity and not tr.HitWorld then

--- a/corpseid/docs/hooks.md
+++ b/corpseid/docs/hooks.md
@@ -80,3 +80,12 @@ end)
 
 ---
 
+
+### Additional Hooks
+
+- `CorpseIdentifyBegin` (`Server`)
+  Player accepted the identification prompt.
+- `CorpseIdentifyDeclined` (`Server`)
+  Player declined the identification prompt.
+- `CorpseIdentifyStarted` (`Server`)
+  Called when the identification action begins.

--- a/corpseid/libraries/server.lua
+++ b/corpseid/libraries/server.lua
@@ -3,6 +3,7 @@
     local targetPlayer = corpse:getNetVar("player")
     if not IsValid(targetPlayer) then return end
     local IDTime = lia.config.get("IdentificationTime", 5)
+    hook.Run("CorpseIdentifyStarted", client, targetPlayer, corpse)
     client:setAction(L("identifyingCorpse"), IDTime, function()
         client:ChatPrint(L("identifiedCorpseMessage", targetPlayer:Nick()))
         hook.Run("CorpseIdentified", client, targetPlayer, corpse)
@@ -13,9 +14,11 @@ function MODULE:PlayerUse(client, entity)
     if IsValid(entity) and entity:GetClass() == "prop_ragdoll" and IsValid(entity:getNetVar("player")) and not client:getNetVar("IdCooldown", false) then
         client:binaryQuestion(L("identifyCorpseQuestion"), L("yes"), L("no"), false, function(choice)
             if choice == 0 then
+                hook.Run("CorpseIdentifyBegin", client, entity)
                 IdentifyCorpse(client, entity)
             else
                 client:notifyLocalized("identifyCorpseDeclined")
+                hook.Run("CorpseIdentifyDeclined", client, entity)
             end
         end)
 

--- a/cursor/docs/hooks.md
+++ b/cursor/docs/hooks.md
@@ -80,3 +80,10 @@ end)
 
 ---
 
+
+### Additional Hooks
+
+- `PreRenderCursor` (`Client`)
+  Called just before the custom cursor is drawn.
+- `PreCursorThink` (`Client`)
+  Called before the hovered panel cursor is changed.

--- a/cursor/libraries/client.lua
+++ b/cursor/libraries/client.lua
@@ -1,6 +1,7 @@
 ﻿local CursorMaterial = ""
 function MODULE:PostRenderVGUI()
     if CursorMaterial ~= "" then
+        hook.Run("PreRenderCursor", CursorMaterial)
         draw.CustCursor(CursorMaterial)
         hook.Run("PostRenderCursor", CursorMaterial)
     end
@@ -10,6 +11,7 @@ function MODULE:Think()
     if CursorMaterial ~= "" then
         local hover_panel = vgui.GetHoveredPanel()
         if not IsValid(hover_panel) then return end
+        hook.Run("PreCursorThink", hover_panel)
         hover_panel:SetCursor("blank")
         hook.Run("CursorThink", hover_panel)
     end

--- a/cutscenes/docs/hooks.md
+++ b/cutscenes/docs/hooks.md
@@ -80,3 +80,12 @@ end)
 
 ---
 
+
+### Additional Hooks
+
+- `CutsceneSceneStarted` (`Client`)
+  Fired when a new cutscene scene begins.
+- `CutsceneSceneEnded` (`Client`)
+  Fired after a scene finishes.
+- `CutsceneSubtitleStarted` (`Client`)
+  Fired when a subtitle line appears.

--- a/cutscenes/libraries/client.lua
+++ b/cutscenes/libraries/client.lua
@@ -65,6 +65,7 @@ function MODULE:runCutscene(id)
             color = s.color,
             font = s.font
         }
+        hook.Run("CutsceneSubtitleStarted", id, s)
     end
 
     local function endScene(last)
@@ -110,6 +111,7 @@ function MODULE:runCutscene(id)
         timer.Simple(scene.startTime, function()
             fadeOut()
             cutStarted = true
+            hook.Run("CutsceneSceneStarted", id, scene)
             setImage(scene.image)
             if scene.sound then
                 if lia.cutsceneMusic then
@@ -139,6 +141,7 @@ function MODULE:runCutscene(id)
                     timer.Simple(self.fadeDelay, function()
                         setImage()
                         pl.scene = nil
+                        hook.Run("CutsceneSceneEnded", id, scene)
                         if idx == #cs then endScene(scene) end
                     end)
                 end

--- a/damagenumbers/docs/hooks.md
+++ b/damagenumbers/docs/hooks.md
@@ -80,3 +80,8 @@ end)
 
 ---
 
+
+### Additional Hooks
+
+- `DamageNumberExpired` (`Client`)
+  Called when a floating damage number disappears.

--- a/damagenumbers/libraries/client.lua
+++ b/damagenumbers/libraries/client.lua
@@ -6,6 +6,7 @@ function MODULE:HUDPaint()
         local dn = damageNumbers[i]
         local timeLeft = dn.time - CurTime()
         if timeLeft <= 0 then
+            hook.Run("DamageNumberExpired", dn.ent, dn.dmg)
             table.remove(damageNumbers, i)
         else
             local alpha = baseAlpha
@@ -32,7 +33,9 @@ net.Receive("expDamageNumbers", function()
         time = CurTime() + lia.option.get("damageNumberTime", 2),
         text = tostring(dmg),
         pos = pos,
-        color = col
+        color = col,
+        ent = ent,
+        dmg = dmg
     })
     hook.Run("DamageNumberAdded", ent, dmg)
 end)

--- a/developmenthud/docs/hooks.md
+++ b/developmenthud/docs/hooks.md
@@ -80,3 +80,8 @@ end)
 
 ---
 
+
+### Additional Hooks
+
+- `DevelopmentHUDPrePaint` (`Client`)
+  Called at the start of the development HUD paint function.

--- a/developmenthud/libraries/client.lua
+++ b/developmenthud/libraries/client.lua
@@ -1,6 +1,7 @@
 ﻿function MODULE:HUDPaint()
     local client = LocalPlayer()
     if not IsValid(client:getChar()) then return end
+    hook.Run("DevelopmentHUDPrePaint", client)
     local devFont = lia.config.get("DevHudFont")
     local x = ScrW() / 5.25
     local baseY = ScrH() / 1.12


### PR DESCRIPTION
## Summary
- fire PreCompassMarkerAdded/PreCompassEntityMarkerAdded before markers are stored
- call CompassSpotCommand when the player runs the console command
- allow interception of corpse identification actions
- add pre-render and pre-think cursor hooks
- send hooks for cutscene scenes and subtitles
- expire damage numbers with a hook
- add a pre-paint hook for the development HUD
- document new hooks in each module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874d248bec48327842d850bb5f66ea7