### PR TITLE
Update hook docs for several modules

### DIFF
--- a/slowweapons/docs/hooks.md
+++ b/slowweapons/docs/hooks.md
@@ -1,52 +1,86 @@
-### `<HookName>`
+### `OverrideSlowWeaponSpeed`
 
 **Purpose**
-`%Purpose%`
+`Override the slow walk speed for a specific weapon before it is applied.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `client` (`Player`): `The player who is moving.`
+* `weapon` (`Weapon`): `The weapon affecting the player's speed.`
+* `speed` (`number`): `The base slowdown speed configured for the weapon.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`number` — `New speed to apply. Return nil to use the base speed.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("OverrideSlowWeaponSpeed", "MyHeavyWeaponOverride", function(client, weapon, speed)
+    if weapon:GetClass() == "my_heavy_weapon" then
+        return speed * 1.1
+    end
 end)
 ```
 
-
 ---
 
-### `<HookName>`
+### `ApplyWeaponSlowdown`
 
 **Purpose**
-`%Purpose%`
+`Called right before the player's movement speed is set.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `client` (`Player`): `The player being slowed.`
+* `weapon` (`Weapon`): `The active weapon.`
+* `moveData` (`CMoveData`): `The move data being modified.`
+* `speed` (`number`): `The slowdown speed that will be applied.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("ApplyWeaponSlowdown", "ExtraSlow", function(client, weapon, moveData, speed)
+    if weapon:GetClass() == "my_heavy_weapon" then
+        moveData:SetMaxSpeed(speed * 0.9)
+    end
+end)
+```
+
+---
+
+### `PostApplyWeaponSlowdown`
+
+**Purpose**
+`Runs after the slowdown speed has been applied to the player.`
+
+**Parameters**
+
+* `client` (`Player`): `The affected player.`
+* `weapon` (`Weapon`): `The active weapon.`
+* `moveData` (`CMoveData`): `The move data that was modified.`
+* `speed` (`number`): `The final speed that was applied.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("PostApplyWeaponSlowdown", "NotifySlowdown", function(client, weapon, moveData, speed)
+    if speed < client:GetRunSpeed() then
+        client:ChatPrint("You are slowed down by " .. weapon:GetPrintName())
+    end
 end)
 ```

--- a/stungun/docs/hooks.md
+++ b/stungun/docs/hooks.md
@@ -1,52 +1,206 @@
-### `<HookName>`
+### `PlayerStunned`
 
 **Purpose**
-`%Purpose%`
+`Called when a player is successfully stunned by the stun gun.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `target` (`Player`): `Player that was stunned.`
+* `weapon` (`Entity`): `The stun gun that triggered the stun.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("PlayerStunned", "LogStun", function(target, weapon)
+    print(target:Name() .. " was stunned by " .. weapon:GetOwner():Name())
 end)
 ```
 
-
 ---
 
-### `<HookName>`
+### `PlayerStunCleared`
 
 **Purpose**
-`%Purpose%`
+`Fires after the stun effect ends and the player can move again.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `target` (`Player`): `Player whose stun has ended.`
+* `weapon` (`Entity`): `The stun gun involved.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("PlayerStunCleared", "OnStunEnd", function(target)
+    target:ChatPrint("You can move again.")
+end)
+```
+
+---
+
+### `PlayerOverStunned`
+
+**Purpose**
+`Triggered when a player is over-stunned and takes damage.`
+
+**Parameters**
+
+* `target` (`Player`): `Player that has been over-stunned.`
+* `weapon` (`Entity`): `The stun gun that caused it.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("PlayerOverStunned", "AlertOverStun", function(target)
+    target:EmitSound("npc/roller/blade_in.wav")
+end)
+```
+
+---
+
+### `PlayerOverStunCleared`
+
+**Purpose**
+`Runs once an over-stun effect has finished.`
+
+**Parameters**
+
+* `target` (`Player`): `Player freed from over-stun.`
+* `weapon` (`Entity`): `The stun gun responsible.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("PlayerOverStunCleared", "OverStunEnd", function(target)
+    target:ChatPrint("Over-stun ended.")
+end)
+```
+
+---
+
+### `StunGunReloaded`
+
+**Purpose**
+`Called after the stun gun finishes reloading.`
+
+**Parameters**
+
+* `owner` (`Player`): `Player who reloaded the weapon.`
+* `weapon` (`Entity`): `The stun gun that was reloaded.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("StunGunReloaded", "RechargeNotice", function(owner)
+    owner:ChatPrint("Taser reloaded")
+end)
+```
+
+---
+
+### `StunGunLaserToggled`
+
+**Purpose**
+`Fires whenever the laser sight on the stun gun is toggled.`
+
+**Parameters**
+
+* `owner` (`Player`): `Player toggling the laser.`
+* `enabled` (`boolean`): `Whether the laser is now on.`
+* `weapon` (`Entity`): `The stun gun.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("StunGunLaserToggled", "LaserSound", function(owner, enabled)
+    owner:EmitSound(enabled and "buttons/button17.wav" or "buttons/button18.wav")
+end)
+```
+
+---
+
+### `StunGunFired`
+
+**Purpose**
+`Called when the stun gun fires and a target is shocked.`
+
+**Parameters**
+
+* `owner` (`Player`): `Player who fired the stun gun.`
+* `target` (`Player`): `Player that was hit.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("StunGunFired", "BroadcastStun", function(owner, target)
+    PrintMessage(HUD_PRINTTALK, owner:Name() .. " stunned " .. target:Name())
+end)
+```
+
+---
+
+### `StunGunTethered`
+
+**Purpose**
+`Runs when a rope tether is successfully attached to a target.`
+
+**Parameters**
+
+* `owner` (`Player`): `Player holding the stun gun.`
+* `target` (`Player`): `Player that the rope attached to.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("StunGunTethered", "TetherMsg", function(owner, target)
+    owner:ChatPrint("Tethered to " .. target:Name())
 end)
 ```

--- a/tying/docs/hooks.md
+++ b/tying/docs/hooks.md
@@ -1,52 +1,175 @@
-### `<HookName>`
+### `PlayerStartUnTying`
 
 **Purpose**
-`%Purpose%`
+`Called when a player begins untying another player.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `actor` (`Player`): `Player attempting to untie.`
+* `target` (`Player`): `Player being untied.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("PlayerStartUnTying", "NotifyStartUnTie", function(actor, target)
+    actor:ChatPrint("You begin untying " .. target:Name())
 end)
 ```
 
-
 ---
 
-### `<HookName>`
+### `PlayerFinishUnTying`
 
 **Purpose**
-`%Purpose%`
+`Runs when the untying process successfully completes.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `actor` (`Player`): `Player who untied the target.`
+* `target` (`Player`): `Player that was untied.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("PlayerFinishUnTying", "CelebrateUnTie", function(actor, target)
+    actor:EmitSound("npc/roller/blade_in.wav")
+end)
+```
+
+---
+
+### `PlayerUnTieAborted`
+
+**Purpose**
+`Fires if the untying action is cancelled before completion.`
+
+**Parameters**
+
+* `actor` (`Player`): `Player who attempted the untying.`
+* `target` (`Player`): `Player that remained tied.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("PlayerUnTieAborted", "AbortNotice", function(actor, target)
+    actor:ChatPrint("Untying failed.")
+end)
+```
+
+---
+
+### `PlayerStartHandcuff`
+
+**Purpose**
+`Called when a player first becomes handcuffed.`
+
+**Parameters**
+
+* `target` (`Player`): `Player being handcuffed.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("PlayerStartHandcuff", "HandcuffSound", function(target)
+    target:EmitSound("npc/metropolice/gear1.wav")
+end)
+```
+
+---
+
+### `PlayerHandcuffed`
+
+**Purpose**
+`Runs after the handcuff procedure finishes.`
+
+**Parameters**
+
+* `target` (`Player`): `Player that is now handcuffed.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("PlayerHandcuffed", "RestrictChat", function(target)
+    target:ChatPrint("You have been restrained.")
+end)
+```
+
+---
+
+### `ResetSubModuleCuffData`
+
+**Purpose**
+`Signals submodules to clear any cuff related data when cuffs are removed.`
+
+**Parameters**
+
+* `target` (`Player`): `Player whose cuff data should reset.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("ResetSubModuleCuffData", "ClearSearch", function(target)
+    -- remove search permissions or other submodule data
+end)
+```
+
+---
+
+### `PlayerUnhandcuffed`
+
+**Purpose**
+`Fires after a player has been fully unhandcuffed.`
+
+**Parameters**
+
+* `target` (`Player`): `Player that is no longer restrained.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("PlayerUnhandcuffed", "FreedomMsg", function(target)
+    target:ChatPrint("You are free to go.")
 end)
 ```

--- a/viewbob/docs/hooks.md
+++ b/viewbob/docs/hooks.md
@@ -1,52 +1,55 @@
-### `<HookName>`
+### `ViewBobPunch`
 
 **Purpose**
-`%Purpose%`
+`Allows custom effects whenever the module applies a view punch.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `client` (`Player`): `The local player receiving the view punch.`
+* `angleX` (`number`): `Pitch component.`
+* `angleY` (`number`): `Yaw component.`
+* `angleZ` (`number`): `Roll component.`
 
 **Realm**
-`%Client|Server%`
+`Client`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("ViewBobPunch", "ScreenShake", function(client, x, y, z)
+    if x > 2 then
+        util.ScreenShake(client:GetPos(), 5, 5, 0.25, 100)
+    end
 end)
 ```
 
-
 ---
 
-### `<HookName>`
+### `ViewBobStep`
 
 **Purpose**
-`%Purpose%`
+`Called each time the player takes a step to allow overriding the step value.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `client` (`Player`): `The stepping player.`
+* `step` (`number`): `1 or -1 indicating step direction.`
 
 **Realm**
-`%Client|Server%`
+`Client`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`number` — `New step value to use.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("ViewBobStep", "InvertBob", function(client, step)
+    if client:Crouching() then
+        return -step
+    end
 end)
 ```

--- a/vmanip/docs/hooks.md
+++ b/vmanip/docs/hooks.md
@@ -1,52 +1,51 @@
-### `<HookName>`
+### `PreVManipPickup`
 
 **Purpose**
-`%Purpose%`
+`Runs before the pickup animation message is sent to the client.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `client` (`Player`): `Player picking up the item.`
+* `item` (`Item`): `Item that is being picked up.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("PreVManipPickup", "BlockCertainItems", function(client, item)
+    if item.uniqueID == "restricted" then
+        return false
+    end
 end)
 ```
 
-
 ---
 
-### `<HookName>`
+### `VManipPickup`
 
 **Purpose**
-`%Purpose%`
+`Called after the pickup animation network message is sent.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `client` (`Player`): `Player that picked up the item.`
+* `item` (`Item`): `Item that was picked up.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("VManipPickup", "PlaySound", function(client, item)
+    client:EmitSound("items/ammo_pickup.wav")
 end)
 ```

--- a/warrants/docs/hooks.md
+++ b/warrants/docs/hooks.md
@@ -1,52 +1,82 @@
-### `<HookName>`
+### `PreWarrantToggle`
 
 **Purpose**
-`%Purpose%`
+`Called just before a character's warrant status is changed.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `character` (`Character`): `Character whose warrant state is toggling.`
+* `warranter` (`Player`): `Player issuing or removing the warrant.`
+* `warranted` (`boolean`): `Whether the character is becoming warranted.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("PreWarrantToggle", "LogAttempt", function(char, actor, warranted)
+    print("Warrant change for " .. char:getName())
 end)
 ```
 
-
 ---
 
-### `<HookName>`
+### `WarrantStatusChanged`
 
 **Purpose**
-`%Purpose%`
+`Fires immediately after the warrant flag is updated.`
 
 **Parameters**
 
-* `%param1%` (`%type1%`): `%Description of param1%`
-* `%param2%` (`%type2%`): `%Description of param2%`
-* *…add more as needed…*
+* `character` (`Character`): `Character that had their warrant status updated.`
+* `warranter` (`Player`): `Player responsible for the change.`
+* `warranted` (`boolean`): `Current warrant status.`
 
 **Realm**
-`%Client|Server%`
+`Server`
 
 **Returns**
-`%ReturnType%` — `%Description of return value%`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("%HookName%", "%Identifier%", function(%param1%, %param2%)
-    %BodyImplementation%
+hook.Add("WarrantStatusChanged", "NotifyAdmins", function(char, actor, warranted)
+    if warranted then
+        PrintMessage(HUD_PRINTTALK, char:getName() .. " is now warranted")
+    end
+end)
+```
+
+---
+
+### `PostWarrantToggle`
+
+**Purpose**
+`Runs after notifications about a warrant have been sent.`
+
+**Parameters**
+
+* `character` (`Character`): `Character that was affected.`
+* `warranter` (`Player`): `Player who issued or cleared the warrant.`
+* `warranted` (`boolean`): `Whether the warrant is active after the change.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil` — `Return value is ignored.`
+
+**Example**
+
+```lua
+hook.Add("PostWarrantToggle", "Cleanup", function(char, actor, warranted)
+    if not warranted then
+        -- custom cleanup here
+    end
 end)
 ```


### PR DESCRIPTION
## Summary
- expand hook documentation for `slowweapons`, `stungun`, `tying`, `viewbob`, `vmanip`, and `warrants`
- replace placeholders with real hook descriptions and examples

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874dd84c24483278892e3fdedd04597