### PR TITLE
Add extra hook events

### DIFF
--- a/alcoholism/docs/hooks.md
+++ b/alcoholism/docs/hooks.md
@@ -99,3 +99,158 @@ hook.Add("AlcoholConsumed", "LogDrink", function(client, item)
     print(client:Name() .. " drank " .. item.name)
 end)
 ```
+
+---
+
+### `PreBACReset`
+
+**Purpose**
+`Runs right before a player's BAC value is cleared.`
+
+**Parameters**
+
+* `client` (`Player`): `The player about to be reset.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("PreBACReset", "LogBeforeReset", function(client)
+    print(client:Name() .. " BAC resetting")
+end)
+```
+
+---
+
+### `PostBACReset`
+
+**Purpose**
+`Called after a player's BAC has been cleared.`
+
+**Parameters**
+
+* `client` (`Player`): `The player that was reset.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("PostBACReset", "AfterReset", function(client)
+    -- cleanup
+end)
+```
+
+---
+
+### `PreBACIncrease`
+
+**Purpose**
+`Invoked before a player's BAC value increases.`
+
+**Parameters**
+
+* `client` (`Player`): `The affected player.`
+* `amount` (`number`): `Amount being added.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("PreBACIncrease", "CheckIncrease", function(client, amount)
+    if amount > 50 then return false end
+end)
+```
+
+---
+
+### `BACThresholdReached`
+
+**Purpose**
+`Fires when a player's BAC crosses the drunk threshold.`
+
+**Parameters**
+
+* `client` (`Player`): `The player who crossed the threshold.`
+* `newBac` (`number`): `Their new BAC value.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("BACThresholdReached", "AlertAdmins", function(client, bac)
+    print(client:Name() .. " is drunk at " .. bac .. "%")
+end)
+```
+
+---
+
+### `PreBACDecrease`
+
+**Purpose**
+`Runs before the server lowers a player's BAC over time.`
+
+**Parameters**
+
+* `client` (`Player`): `Player whose BAC will drop.`
+* `current` (`number`): `Their current BAC before drop.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("PreBACDecrease", "CheckDrop", function(client, current)
+    -- You could modify decay here
+end)
+```
+
+---
+
+### `PostBACDecrease`
+
+**Purpose**
+`Runs after a player's BAC has decayed for the tick.`
+
+**Parameters**
+
+* `client` (`Player`): `Affected player.`
+* `newBac` (`number`): `Their BAC after decay.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("PostBACDecrease", "NotifyDrop", function(client, newBac)
+    print("BAC now", newBac)
+end)
+```
+

--- a/alcoholism/libraries/server.lua
+++ b/alcoholism/libraries/server.lua
@@ -5,9 +5,11 @@ function MODULE:Think()
         for _, client in player.Iterator() do
             local bac = client:getNetVar("lia_alcoholism_bac", 0)
             if bac > 0 then
+                hook.Run("PreBACDecrease", client, bac)
                 local newBac = math.Clamp(bac - lia.config.get("AlcoholDegradeRate", 5), 0, 100)
                 client:setNetVar("lia_alcoholism_bac", newBac)
                 hook.Run("BACChanged", client, newBac)
+                hook.Run("PostBACDecrease", client, newBac)
             end
         end
 

--- a/alcoholism/meta/sh_player.lua
+++ b/alcoholism/meta/sh_player.lua
@@ -1,17 +1,25 @@
 ﻿local playerMeta = FindMetaTable("Player")
 if SERVER then
     function playerMeta:ResetBAC()
+        hook.Run("PreBACReset", self)
         self:setNetVar("lia_alcoholism_bac", 0)
         hook.Run("BACChanged", self, 0)
         hook.Run("BACReset", self)
+        hook.Run("PostBACReset", self)
     end
 
     function playerMeta:AddBAC(amt)
         if not amt or not isnumber(amt) then return end
-        local newBac = math.Clamp(self:getNetVar("lia_alcoholism_bac", 0) + amt, 0, 100)
+        hook.Run("PreBACIncrease", self, amt)
+        local oldBac = self:getNetVar("lia_alcoholism_bac", 0)
+        local newBac = math.Clamp(oldBac + amt, 0, 100)
         self:setNetVar("lia_alcoholism_bac", newBac)
         hook.Run("BACChanged", self, newBac)
         hook.Run("BACIncreased", self, amt, newBac)
+        local threshold = lia.config.get("DrunkNotifyThreshold", 50)
+        if oldBac < threshold and newBac >= threshold then
+            hook.Run("BACThresholdReached", self, newBac)
+        end
     end
 end
 

--- a/bodygrouper/commands.lua
+++ b/bodygrouper/commands.lua
@@ -15,6 +15,7 @@
             return
         end
 
+        hook.Run("PreBodygrouperMenuOpen", client, target)
         net.Start("BodygrouperMenu")
         net.WriteEntity(target)
         net.Send(client)

--- a/bodygrouper/docs/hooks.md
+++ b/bodygrouper/docs/hooks.md
@@ -229,3 +229,141 @@ hook.Add("PostBodygroupApply", "AnnounceChanges", function(client, target, skin,
     print(target:Name() .. " updated appearance")
 end)
 ```
+
+---
+
+### `PreBodygrouperMenuOpen`
+
+**Purpose**
+`Runs server-side before the bodygrouper menu is opened for a player.`
+
+**Parameters**
+
+* `client` (`Player`): `Player requesting the menu.`
+* `target` (`Entity`): `Entity whose bodygroups will be edited.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("PreBodygrouperMenuOpen", "LogOpen", function(c, t)
+    print(c:Name() .. " is viewing " .. t:Name())
+end)
+```
+
+---
+
+### `BodygrouperApplyAttempt`
+
+**Purpose**
+`Called when the server receives a request to apply bodygroup changes.`
+
+**Parameters**
+
+* `client` (`Player`): `Player applying changes.`
+* `target` (`Entity`): `Target entity.`
+* `skin` (`number`): `Requested skin index.`
+* `groups` (`table`): `Requested bodygroup values.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("BodygrouperApplyAttempt", "LogAttempt", function(c, t, skn)
+    print(c:Name(), "attempting bodygroup edit on", t)
+end)
+```
+
+---
+
+### `BodygrouperInvalidSkin`
+
+**Purpose**
+`Runs when a player selects a skin index the target does not support.`
+
+**Parameters**
+
+* `client` (`Player`): `Player who made the request.`
+* `target` (`Entity`): `Target entity.`
+* `skin` (`number`): `Invalid skin index.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("BodygrouperInvalidSkin", "Warn", function(c, t, skn)
+    print("Invalid skin", skn)
+end)
+```
+
+---
+
+### `BodygrouperInvalidGroup`
+
+**Purpose**
+`Called when a bodygroup value exceeds the entity's allowed range.`
+
+**Parameters**
+
+* `client` (`Player`): `Player making the request.`
+* `target` (`Entity`): `Target entity.`
+* `index` (`number`): `Bodygroup index.`
+* `value` (`number`): `Invalid value provided.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("BodygrouperInvalidGroup", "Debug", function(c, t, idx, val)
+    print("Invalid group", idx, val)
+end)
+```
+
+---
+
+### `BodygrouperValidated`
+
+**Purpose**
+`Fires after validation passes but before changes apply.`
+
+**Parameters**
+
+* `client` (`Player`): `Player applying changes.`
+* `target` (`Entity`): `Target entity.`
+* `skin` (`number`): `Skin index to set.`
+* `groups` (`table`): `Bodygroup values.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("BodygrouperValidated", "Notify", function(c, t)
+    print("Validated bodygroup edit for", c:Name())
+end)
+```
+

--- a/bodygrouper/netcalls/server.lua
+++ b/bodygrouper/netcalls/server.lua
@@ -12,6 +12,7 @@ net.Receive("BodygrouperMenu", function(_, client)
     local skn = net.ReadUInt(10)
     local groups = net.ReadTable()
     local closetuser = false
+    hook.Run("BodygrouperApplyAttempt", client, target, skn, groups)
     if not IsValid(target) then return end
     if target ~= client then
         if not client:hasPrivilege("Commands - Change Bodygroups") then
@@ -28,6 +29,7 @@ net.Receive("BodygrouperMenu", function(_, client)
     end
 
     if target:SkinCount() and skn > target:SkinCount() then
+        hook.Run("BodygrouperInvalidSkin", client, target, skn)
         client:notifyLocalized("invalidSkin")
         return
     end
@@ -35,11 +37,14 @@ net.Receive("BodygrouperMenu", function(_, client)
     if target:GetNumBodyGroups() and target:GetNumBodyGroups() > 0 then
         for k, v in pairs(groups) do
             if v > target:GetBodygroupCount(k) then
+                hook.Run("BodygrouperInvalidGroup", client, target, k, v)
                 client:notifyLocalized("invalidBodygroup")
                 return
             end
         end
     end
+
+    hook.Run("BodygrouperValidated", client, target, skn, groups)
 
     hook.Run("PreBodygroupApply", client, target, skn, groups)
     local character = target:getChar()

--- a/broadcasts/commands.lua
+++ b/broadcasts/commands.lua
@@ -16,7 +16,9 @@
             table.insert(options, class.name .. " (" .. class.uniqueID .. ")")
         end
 
+        hook.Run("ClassBroadcastMenuOpened", client, options)
         client:requestOptions(L("classBroadcastTitle"), L("selectClassesPrompt"), options, #options, function(selectedOptions)
+            hook.Run("ClassBroadcastMenuClosed", client, selectedOptions)
             local classList = {}
             local classListSimple = {}
             for _, v in ipairs(selectedOptions) do
@@ -46,6 +48,7 @@
             client:notifyLocalized("classBroadcastSent")
             hook.Run("ClassBroadcastSent", client, message, classListSimple)
             lia.log.add(client, "classbroadcast", message)
+            hook.Run("ClassBroadcastLogged", client, message, classListSimple)
         end)
     end,
 })
@@ -68,7 +71,9 @@ lia.command.add("factionbroadcast", {
             table.insert(options, faction.name .. " (" .. faction.uniqueID .. ")")
         end
 
+        hook.Run("FactionBroadcastMenuOpened", client, options)
         client:requestOptions(L("factionBroadcastTitle"), L("selectFactionsPrompt"), options, #options, function(selectedOptions)
+            hook.Run("FactionBroadcastMenuClosed", client, selectedOptions)
             local factionList = {}
             local factionListSimple = {}
             for _, v in ipairs(selectedOptions) do
@@ -98,6 +103,7 @@ lia.command.add("factionbroadcast", {
             client:notifyLocalized("factionBroadcastSent")
             hook.Run("FactionBroadcastSent", client, message, factionListSimple)
             lia.log.add(client, "factionbroadcast", message)
+            hook.Run("FactionBroadcastLogged", client, message, factionListSimple)
         end)
     end,
 })

--- a/broadcasts/docs/hooks.md
+++ b/broadcasts/docs/hooks.md
@@ -103,3 +103,162 @@ hook.Add("FactionBroadcastSent", "LogFactionBroadcast", function(client, message
     print(table.concat(factions, ", "))
 end)
 ```
+
+---
+
+### `ClassBroadcastMenuOpened`
+
+**Purpose**
+`Fires when the class broadcast selection menu is presented.`
+
+**Parameters**
+
+* `client` (`Player`): `Player opening the menu.`
+* `options` (`table`): `List of class option strings.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("ClassBroadcastMenuOpened", "ModifyOptions", function(client, opts)
+    table.sort(opts)
+end)
+```
+
+---
+
+### `ClassBroadcastMenuClosed`
+
+**Purpose**
+`Runs after the player has finished selecting classes.`
+
+**Parameters**
+
+* `client` (`Player`): `The selecting player.`
+* `selection` (`table`): `Strings chosen from the list.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("ClassBroadcastMenuClosed", "LogSelection", function(client, selection)
+    PrintTable(selection)
+end)
+```
+
+---
+
+### `ClassBroadcastLogged`
+
+**Purpose**
+`Called after a class broadcast has been logged.`
+
+**Parameters**
+
+* `client` (`Player`): `The broadcaster.`
+* `message` (`string`): `Broadcast text.`
+* `classes` (`table`): `Class names sent to.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("ClassBroadcastLogged", "NotifyAdmins", function(client, msg)
+    print("Logged class BC", msg)
+end)
+```
+
+---
+
+### `FactionBroadcastMenuOpened`
+
+**Purpose**
+`Fires when the faction broadcast selection menu appears.`
+
+**Parameters**
+
+* `client` (`Player`): `Opening player.`
+* `options` (`table`): `List of faction option strings.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("FactionBroadcastMenuOpened", "SortFactions", function(client, opts)
+    table.sort(opts)
+end)
+```
+
+---
+
+### `FactionBroadcastMenuClosed`
+
+**Purpose**
+`Runs after faction options have been chosen.`
+
+**Parameters**
+
+* `client` (`Player`): `Selecting player.`
+* `selection` (`table`): `Chosen faction strings.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("FactionBroadcastMenuClosed", "LogFactionSel", function(c, sel)
+    PrintTable(sel)
+end)
+```
+
+---
+
+### `FactionBroadcastLogged`
+
+**Purpose**
+`Called after a faction broadcast entry is logged.`
+
+**Parameters**
+
+* `client` (`Player`): `The broadcaster.`
+* `message` (`string`): `Broadcast text.`
+* `factions` (`table`): `Faction names.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("FactionBroadcastLogged", "NotifyLog", function(client, msg)
+    print("Logged faction BC", msg)
+end)
+```
+

--- a/rumour/commands.lua
+++ b/rumour/commands.lua
@@ -3,19 +3,25 @@
     syntax = "[string Message]",
     desc = L("rumourCommandDesc"),
     onRun = function(client, arguments)
+        hook.Run("PreRumourCommand", client, arguments)
         local faction = lia.faction.indices[client:Team()]
         if not faction or not faction.criminal then
+            hook.Run("RumourFactionDisallowed", client, faction)
             client:ChatPrint(L("rumourNotAllowed"))
             return
         end
 
         local rumourMessage = table.concat(arguments, " ")
         if rumourMessage == "" then
+            hook.Run("RumourNoMessage", client)
             client:ChatPrint(L("rumourNoMessage"))
             return
         end
 
-        if hook.Run("CanSendRumour", client, rumourMessage) == false then return end
+        if hook.Run("CanSendRumour", client, rumourMessage) == false then
+            hook.Run("RumourValidationFailed", client, rumourMessage)
+            return
+        end
         if not client.rumourdelay then client.rumourdelay = 0 end
         if CurTime() < client.rumourdelay then
             local seconds = math.ceil(client.rumourdelay - CurTime())
@@ -27,6 +33,7 @@
         client.rumourdelay = CurTime() + lia.config.get("RumourCooldown", 60)
         local revealChance = lia.config.get("RumourRevealChance", 0.02)
         local revealMath = math.random() < revealChance
+        hook.Run("RumourRevealRoll", client, revealChance, revealMath)
         for _, target in player.Iterator() do
             local targetFaction = lia.faction.indices[target:Team()]
             if targetFaction and targetFaction.criminal then
@@ -36,6 +43,9 @@
             end
         end
 
+        if revealMath then
+            hook.Run("RumourRevealed", client)
+        end
         hook.Run("RumourSent", client, rumourMessage, revealMath)
     end
 })

--- a/rumour/docs/hooks.md
+++ b/rumour/docs/hooks.md
@@ -78,3 +78,159 @@ hook.Add("RumourSent", "NotifyReveal", function(client, text, revealed)
     end
 end)
 ```
+
+---
+
+### `PreRumourCommand`
+
+**Purpose**
+`Runs when a player executes the rumour command before processing.`
+
+**Parameters**
+
+* `client` (`Player`): `The player using the command.`
+* `arguments` (`table`): `Raw command arguments.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("PreRumourCommand", "CapLength", function(client, args)
+    if #args[1] > 200 then return false end
+end)
+```
+
+---
+
+### `RumourFactionDisallowed`
+
+**Purpose**
+`Triggered when a player's faction is not allowed to spread rumours.`
+
+**Parameters**
+
+* `client` (`Player`): `The player denied.`
+* `faction` (`table`|`nil`): `Their faction data.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("RumourFactionDisallowed", "NotifyDenied", function(client)
+    client:notify("Rumours restricted for your faction")
+end)
+```
+
+---
+
+### `RumourNoMessage`
+
+**Purpose**
+`Called when the command is used with no message text.`
+
+**Parameters**
+
+* `client` (`Player`): `The player who tried.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("RumourNoMessage", "HintUsage", function(c)
+    c:ChatPrint("Usage: /rumour <text>")
+end)
+```
+
+---
+
+### `RumourValidationFailed`
+
+**Purpose**
+`Fires when another hook blocks the rumour from sending.`
+
+**Parameters**
+
+* `client` (`Player`): `The player whose rumour was denied.`
+* `text` (`string`): `Rumour text attempted.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("RumourValidationFailed", "LogDeniedRumour", function(client, text)
+    print(client:Name() .. " had rumour blocked: " .. text)
+end)
+```
+
+---
+
+### `RumourRevealRoll`
+
+**Purpose**
+`Runs after the random reveal chance is determined.`
+
+**Parameters**
+
+* `client` (`Player`): `The rumour source.`
+* `chance` (`number`): `Configured reveal probability.`
+* `revealed` (`boolean`): `Result of the roll.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("RumourRevealRoll", "DebugRoll", function(client, chance, revealed)
+    print("Reveal roll:", chance, revealed)
+end)
+```
+
+---
+
+### `RumourRevealed`
+
+**Purpose**
+`Triggered if the player's identity is revealed during a rumour.`
+
+**Parameters**
+
+* `client` (`Player`): `The identified player.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("RumourRevealed", "Embarrass", function(client)
+    client:ChatPrint("Your rumour was traced back to you!")
+end)
+```
+

--- a/viewbob/docs/hooks.md
+++ b/viewbob/docs/hooks.md
@@ -53,3 +53,60 @@ hook.Add("ViewBobStep", "InvertBob", function(client, step)
     end
 end)
 ```
+
+---
+
+### `PreViewPunch`
+
+**Purpose**
+`Called just before the view punch is applied.`
+
+**Parameters**
+
+* `client` (`Player`): `Player receiving the view punch.`
+* `angleX` (`number`): `Pitch component.`
+* `angleY` (`number`): `Yaw component.`
+* `angleZ` (`number`): `Roll component.`
+
+**Realm**
+`Client`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("PreViewPunch", "ClampPunch", function(client, x, y, z)
+    return math.Clamp(x, -5, 5), y, z
+end)
+```
+
+---
+
+### `PostViewPunch`
+
+**Purpose**
+`Runs after the view punch effect has been triggered.`
+
+**Parameters**
+
+* `client` (`Player`): `Player that was punched.`
+* `angleX` (`number`): `Pitch component.`
+* `angleY` (`number`): `Yaw component.`
+* `angleZ` (`number`): `Roll component.`
+
+**Realm**
+`Client`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("PostViewPunch", "PostEffects", function(client)
+    -- apply additional effects
+end)
+```
+

--- a/viewbob/libraries/client.lua
+++ b/viewbob/libraries/client.lua
@@ -1,7 +1,9 @@
 ﻿local stepvalue = 0
 local function applyViewPunch(client, angleX, angleY, angleZ)
+    hook.Run("PreViewPunch", client, angleX, angleY, angleZ)
     hook.Run("ViewBobPunch", client, angleX, angleY, angleZ)
     if IsValid(client) then client:ViewPunch(Angle(angleX, angleY, angleZ)) end
+    hook.Run("PostViewPunch", client, angleX, angleY, angleZ)
 end
 
 function MODULE:PlayerFootstep(client)

--- a/wordfilter/docs/hooks.md
+++ b/wordfilter/docs/hooks.md
@@ -78,3 +78,107 @@ hook.Add("PostFilterCheck", "Example_PostFilterCheck", function(ply, text, passe
 end)
 ```
 
+
+---
+
+### `FilterCheckFailed`
+
+**Purpose**
+`Called when a player's message is blocked for containing a banned word.`
+
+**Parameters**
+
+* `ply` (`Player`): `The offending player.`
+* `text` (`string`): `Original chat text.`
+* `word` (`string`): `The banned word found.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("FilterCheckFailed", "LogFailure", function(ply, text, bad)
+    print(ply:Name() .. " used disallowed word " .. bad)
+end)
+```
+
+---
+
+### `FilterCheckPassed`
+
+**Purpose**
+`Runs when a player's chat message passes the filter.`
+
+**Parameters**
+
+* `ply` (`Player`): `Player whose message was allowed.`
+* `text` (`string`): `Their original message.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("FilterCheckPassed", "LogPass", function(ply, text)
+    print("Allowed chat:", text)
+end)
+```
+
+---
+
+### `WordAddedToFilter`
+
+**Purpose**
+`Fires after a new word is added to the blacklist.`
+
+**Parameters**
+
+* `word` (`string`): `The word that was inserted.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("WordAddedToFilter", "Announce", function(word)
+    print("Added banned word:", word)
+end)
+```
+
+---
+
+### `WordRemovedFromFilter`
+
+**Purpose**
+`Called after a word is removed from the blacklist.`
+
+**Parameters**
+
+* `word` (`string`): `The word removed.`
+
+**Realm**
+`Server`
+
+**Returns**
+`nil`
+
+**Example**
+
+```lua
+hook.Add("WordRemovedFromFilter", "AnnounceRemove", function(word)
+    print("Removed banned word:", word)
+end)
+```
+

--- a/wordfilter/libraries/shared.lua
+++ b/wordfilter/libraries/shared.lua
@@ -1,4 +1,60 @@
-﻿local blacklist = {"nigger", "faggot", "chink", "kike", "spic", "gook", "wetback", "dyke", "tranny", "retard", "coon", "raghead", "nip", "honky", "gyp", "beaner", "paki", "slant", "slope", "jap"}
+local blacklist = {
+    "nigger",
+    "faggot",
+    "chink",
+    "kike",
+    "spic",
+    "gook",
+    "wetback",
+    "dyke",
+    "tranny",
+    "retard",
+    "coon",
+    "raghead",
+    "nip",
+    "honky",
+    "gyp",
+    "beaner",
+    "paki",
+    "slant",
+    "slope",
+    "jap"
+}
+
+function MODULE:LoadData()
+    local stored = self:getData({})
+    if istable(stored) then
+        for _, word in ipairs(stored) do
+            if not table.HasValue(blacklist, word) then
+                table.insert(blacklist, word)
+            end
+        end
+    end
+end
+
+function MODULE:SaveData()
+    self:setData(blacklist)
+end
+
+function MODULE:AddBlacklistedWord(word)
+    if not word then return end
+    if table.HasValue(blacklist, word) then return end
+    table.insert(blacklist, word)
+    self:SaveData()
+    hook.Run("WordAddedToFilter", word)
+end
+
+function MODULE:RemoveBlacklistedWord(word)
+    if not word then return end
+    for i, v in ipairs(blacklist) do
+        if v == word then
+            table.remove(blacklist, i)
+            self:SaveData()
+            hook.Run("WordRemovedFromFilter", word)
+            break
+        end
+    end
+end
 function MODULE:PlayerSay(ply, text)
     hook.Run("PreFilterCheck", ply, text)
     local lowerText = text:lower()
@@ -6,10 +62,12 @@ function MODULE:PlayerSay(ply, text)
         if lowerText:find(bad, 1, true) then
             hook.Run("FilteredWordUsed", ply, bad, text)
             hook.Run("PostFilterCheck", ply, text, false)
+            hook.Run("FilterCheckFailed", ply, text, bad)
             ply:notifyLocalized("usedFilteredWord")
             return ""
         end
     end
 
     hook.Run("PostFilterCheck", ply, text, true)
+    hook.Run("FilterCheckPassed", ply, text)
 end


### PR DESCRIPTION
## Summary
- expose pre/post BAC functions and new BAC hooks
- extend broadcast command hooks for menus and logging
- add rumour, bodygrouper, wordfilter and viewbob hooks
- document all newly added hooks
- persist added blacklist words to disk

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876743f26e08327a14fff1c16babdb4