### PR TITLE
Fix errors for cigs weapon

### DIFF
--- a/cigs/entities/weapons/weapon_ciga/cl_init.lua
+++ b/cigs/entities/weapons/weapon_ciga/cl_init.lua
@@ -257,8 +257,7 @@ if CLIENT then
         self:UpdateBonePositions(vm)
         if not self.vRenderOrder then
             self.vRenderOrder = {}
-            for _, key in pairs(self.VElements) do
-                local v = self.VElements[key]
+            for key, v in pairs(self.VElements) do
                 if v.type == "Model" then
                     table.insert(self.vRenderOrder, 1, key)
                 elseif v.type == "Sprite" or v.type == "Quad" then

--- a/cigs/entities/weapons/weapon_ciga/shared.lua
+++ b/cigs/entities/weapons/weapon_ciga/shared.lua
@@ -117,14 +117,19 @@ function SWEP:Initialize()
                 angle = Angle(0, 0, 0)
             }
         }
+        -- ensure WElements exists so later code can safely copy it
+        self.WElements = self.WElements or {}
     end
 
     if CLIENT then
         local function tableFullCopy(tab)
             local res = {}
+            if not istable(tab) then
+                return res
+            end
             for k, v in pairs(tab) do
                 if istable(v) then
-                    res[k] = table.FullCopy(v)
+                    res[k] = tableFullCopy(v)
                 elseif isvector(v) then
                     res[k] = Vector(v.x, v.y, v.z)
                 elseif isangle(v) then


### PR DESCRIPTION
## Summary
- ensure `WElements` exists when initializing ciga weapon
- avoid calling `pairs()` on nil values and use safe recursion
- fix ViewModel draw loop to use correct key/value pairs

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877168120f08327ba39eab78885bba9