### PR TITLE
Fix features bullet layout in docs

### DIFF
--- a/scrap_modules.js
+++ b/scrap_modules.js
@@ -53,7 +53,7 @@ for (const module of modulesList) {
   output += `<h2 align="center">${name}${versionLabel}</h2>\n\n`;
   if (description) output += `**Description:** ${description}\n\n`;
   if (features.length) {
-    output += '**Features:**\n';
+    output += '**Features:**\n\n';
     for (const feature of features) output += `- ${feature}\n`;
     output += '\n';
   }


### PR DESCRIPTION
## Summary
- ensure blank line before features list when scraping modules for docs

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68773e3c6ae083279d7d8237c459fc04