### PR TITLE
Fix download link style

### DIFF
--- a/scrap_modules.js
+++ b/scrap_modules.js
@@ -64,7 +64,7 @@ for (const module of modulesList) {
     output += `<p align="center"><a href="${libs}">Libraries</a> | <a href="${hooks}">Hooks</a></p>\n\n`;
   }
   if (download) {
-    output += `<p align="center"><a href="${download}">Download Here</a></p>\n\n`;
+    output += `<p align="center"><a href="${download}"><strong>Download Here</strong></a></p>\n\n`;
   }
 }
 


### PR DESCRIPTION
## Summary
- bold the "Download Here" link in `scrap_modules.js`

## Testing
- `grep -n "Download Here" scrap_modules.js`

------
https://chatgpt.com/codex/tasks/task_e_6877407cba74832788f27694d9720c97