### PR TITLE
Standardize documentation headers

### DIFF
--- a/advert/docs/hooks.md
+++ b/advert/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Advert module.
 
+---
 ### `AdvertSent`
 
 **Purpose**
@@ -23,3 +25,4 @@ hook.Add("AdvertSent", "LogAdvert", function(client, message)
     print(client:Nick() .. " advertised: " .. message)
 end)
 ```
+---

--- a/alcoholism/docs/hooks.md
+++ b/alcoholism/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Alcoholism module.
 
+---
 ### `BACChanged`
 
 **Purpose**
@@ -256,3 +258,4 @@ hook.Add("PostBACDecrease", "NotifyDrop", function(client, newBac)
 end)
 ```
 
+---

--- a/alcoholism/docs/meta.md
+++ b/alcoholism/docs/meta.md
@@ -1,5 +1,8 @@
-# Meta
+# Player Meta
 
+Helper functions for tracking a player's blood alcohol content.
+
+---
 ### Player:ResetBAC (Server)
 
 **Purpose**
@@ -95,3 +98,4 @@ Shared
 ```lua
 local level = client:GetBAC()
 ```
+---

--- a/autorestarter/docs/hooks.md
+++ b/autorestarter/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Autorestarter module.
 
+---
 ### `AutoRestartScheduled`
 
 **Purpose**
@@ -97,3 +99,4 @@ hook.Add("AutoRestartCountdown", "DisplayTimer", function(remaining)
     print(remaining .. " seconds until restart")
 end)
 ```
+---

--- a/bodygrouper/docs/hooks.md
+++ b/bodygrouper/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Bodygrouper module.
 
+---
 ### `BodygrouperClosetAddUser`
 
 **Purpose**
@@ -369,3 +371,4 @@ hook.Add("BodygrouperValidated", "Notify", function(c, t)
 end)
 ```
 
+---

--- a/broadcasts/docs/hooks.md
+++ b/broadcasts/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Broadcasts module.
 
+---
 ### `PreClassBroadcastSend`
 
 **Purpose**
@@ -264,3 +266,4 @@ hook.Add("FactionBroadcastLogged", "NotifyLog", function(client, msg)
 end)
 ```
 
+---

--- a/captions/docs/hooks.md
+++ b/captions/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Captions module.
 
+---
 ### `SendCaptionCommand`
 
 **Purpose**
@@ -104,3 +106,4 @@ hook.Add("CaptionFinished", "HandleCaptionEnd", function(client)
     -- cleanup logic here
 end)
 ```
+---

--- a/captions/docs/libraries.md
+++ b/captions/docs/libraries.md
@@ -1,5 +1,3 @@
-# Libraries
-
 # Caption Library
 
 This page documents the functions for working with on-screen captions.

--- a/cards/docs/hooks.md
+++ b/cards/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Cards module.
 
+---
 ### `CardsCommandUsed`
 
 **Purpose**
@@ -48,3 +50,4 @@ hook.Add("CardDrawn", "AnnounceCard", function(client, card)
     lia.chat.send(client, "me", "drew " .. card)
 end)
 ```
+---

--- a/chatmessages/docs/hooks.md
+++ b/chatmessages/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Chatmessages module.
 
+---
 ### `ChatMessagesTimerStarted`
 
 **Purpose**
@@ -48,3 +50,4 @@ hook.Add("ChatMessageSent", "ReactToMessage", function(index, text)
     chat.AddText(Color(0,255,0), "[Log]", color_white, " Message " .. index .. ": " .. text)
 end)
 ```
+---

--- a/cigs/docs/hooks.md
+++ b/cigs/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Cigs module.
 
+---
 ### `PlayerInhaleSmoke`
 
 **Purpose**
@@ -95,3 +97,4 @@ hook.Add("PlayerStopSmoking", "SmokingEnd", function(player, cigID)
     print(player:Name() .. " stopped smoking")
 end)
 ```
+---

--- a/cinematictext/docs/hooks.md
+++ b/cinematictext/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Cinematictext module.
 
+---
 ### `CinematicDisplayStart`
 
 **Purpose**
@@ -123,3 +125,4 @@ hook.Add("CinematicTriggered", "OnCinematicTrigger", function(client, text, bigT
     print(client:Name() .. " started a cinematic.")
 end)
 ```
+---

--- a/climb/docs/hooks.md
+++ b/climb/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Climb module.
 
+---
 ### `PlayerClimbAttempt`
 
 **Purpose**
@@ -91,3 +93,4 @@ hook.Add("PlayerFailedClimb", "ClimbFail", function(player)
     player:ChatPrint("You can't climb here.")
 end)
 ```
+---

--- a/communitycommands/docs/hooks.md
+++ b/communitycommands/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Communitycommands module.
 
+---
 ### `CommunityURLOpened`
 
 **Purpose**
@@ -46,3 +48,4 @@ hook.Add("CommunityURLRequest", "LogRequest", function(client, command)
     print(client:Name() .. " requested URL for " .. command)
 end)
 ```
+---

--- a/compass/docs/hooks.md
+++ b/compass/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Compass module.
 
+---
 ### `mCompass_loadFonts`
 
 **Purpose**
@@ -199,3 +201,4 @@ hook.Add("CompassSpotCommand", "HandleSpot", function(ply, tr)
     print(ply:Nick() .. " spotted at " .. tostring(tr.HitPos))
 end)
 ```
+---

--- a/corpseid/docs/hooks.md
+++ b/corpseid/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Corpseid module.
 
+---
 ### `RefreshFonts`
 
 **Purpose**
@@ -154,3 +156,4 @@ hook.Add("CorpseCreated", "StoreCorpse", function(client, corpse)
     print("Corpse created for " .. client:Name())
 end)
 ```
+---

--- a/cursor/docs/hooks.md
+++ b/cursor/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Cursor module.
 
+---
 ### `PreRenderCursor`
 
 **Purpose**
@@ -97,3 +99,4 @@ hook.Add("CursorThink", "Example", function(panel)
     -- custom panel hover logic here
 end)
 ```
+---

--- a/cutscenes/docs/hooks.md
+++ b/cutscenes/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Cutscenes module.
 
+---
 ### `CutsceneStarted`
 
 **Purpose**
@@ -126,3 +128,4 @@ hook.Add("CutsceneSubtitleStarted", "Subtitle", function(id, sub)
     print(sub.text)
 end)
 ```
+---

--- a/damagenumbers/docs/hooks.md
+++ b/damagenumbers/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Damagenumbers module.
 
+---
 ### `RefreshFonts`
 
 **Purpose**
@@ -101,3 +103,4 @@ hook.Add("DamageNumberExpired", "OnExpire", function(ent, dmg)
     print("Damage number " .. dmg .. " expired")
 end)
 ```
+---

--- a/developmenthud/docs/hooks.md
+++ b/developmenthud/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Developmenthud module.
 
+---
 ### `RefreshFonts`
 
 **Purpose**
@@ -72,3 +74,4 @@ hook.Add("DevelopmentHUDPaint", "PostHUD", function(ply)
     -- draw additional overlays here
 end)
 ```
+---

--- a/developmentserver/docs/hooks.md
+++ b/developmentserver/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Developmentserver module.
 
+---
 ### `DevServerUnauthorized`
 
 **Purpose**
@@ -98,3 +100,4 @@ hook.Add("DevServerModeDeactivated", "AnnounceDevModeOff", function()
 end)
 ```
 
+---

--- a/discordrelay/docs/hooks.md
+++ b/discordrelay/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Discordrelay module.
 
+---
 ### `DiscordRelaySend`
 
 **Purpose**
@@ -73,3 +75,4 @@ hook.Add("DiscordRelayUnavailable", "NotifyMissing", function()
 end)
 ```
 
+---

--- a/donator/docs/hooks.md
+++ b/donator/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Donator module.
 
+---
 ### `DonatorFlagsGranted`
 
 **Purpose**
@@ -258,3 +260,4 @@ hook.Add("DonatorAdditionalSlotsGiven", "TrackAddSlots", function(player, amount
 end)
 ```
 
+---

--- a/donator/docs/meta.md
+++ b/donator/docs/meta.md
@@ -1,5 +1,8 @@
-# Meta
+# Player Meta
 
+Functions managing a player's extra character slots for donors.
+
+---
 ### Player:GetAdditionalCharSlots (Shared)
 
 **Purpose**
@@ -69,3 +72,4 @@ Server
 ```lua
 client:GiveAdditionalCharSlots(2)
 ```
+---

--- a/doorkick/docs/hooks.md
+++ b/doorkick/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Doorkick module.
 
+---
 ### `DoorKickFailed`
 
 **Purpose**
@@ -77,3 +79,4 @@ hook.Add("DoorKickedOpen", "LogDoorKick", function(client, door)
 end)
 ```
 
+---

--- a/enhanceddeath/docs/hooks.md
+++ b/enhanceddeath/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Enhanceddeath module.
 
+---
 ### `HospitalRespawned`
 
 **Purpose**
@@ -75,3 +77,4 @@ hook.Add("HospitalDeathFlagged", "AnnounceFlag", function(client)
 end)
 ```
 
+---

--- a/extendeddescriptions/docs/hooks.md
+++ b/extendeddescriptions/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Extendeddescriptions module.
 
+---
 ### `ExtendedDescriptionOpened`
 
 **Purpose**
@@ -184,3 +186,4 @@ hook.Add("ExtendedDescriptionUpdated", "announceUpdate", function(client, url, t
     client:ChatPrint("Your description was saved!")
 end)
 ```
+---

--- a/firstpersoneffects/docs/hooks.md
+++ b/firstpersoneffects/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Firstpersoneffects module.
 
+---
 ### `ShouldUseFirstPersonEffects`
 
 **Purpose**
@@ -101,3 +103,4 @@ hook.Add("FirstPersonEffectsUpdated", "StoreOffsets", function(pl, pos, ang)
     MyAddon.LastOffset = pos
 end)
 ```
+---

--- a/flashlight/docs/hooks.md
+++ b/flashlight/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Flashlight module.
 
+---
 ### `PrePlayerToggleFlashlight`
 
 **Purpose**
@@ -78,3 +80,4 @@ hook.Add("PlayerToggleFlashlight", "Announce", function(client, state)
     print(client:Name() .. " turned their flashlight " .. word)
 end)
 ```
+---

--- a/freelook/docs/hooks.md
+++ b/freelook/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Freelook module.
 
+---
 ### `ShouldUseFreelook`
 
 **Purpose**
@@ -72,3 +74,4 @@ hook.Add("FreelookToggled", "Notify", function(state)
     print("Freelook state:", state)
 end)
 ```
+---

--- a/gamemasterpoints/docs/hooks.md
+++ b/gamemasterpoints/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Gamemasterpoints module.
 
+---
 ### `GamemasterPreAddPoint`
 
 **Purpose**
@@ -318,3 +320,4 @@ hook.Add("GamemasterMoveToPoint", "NotifyMove", function(client, name, pos)
     print(client, "arrived at", name)
 end)
 ```
+---

--- a/hud_extras/docs/hooks.md
+++ b/hud_extras/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the HudExtras module.
 
+---
 ### `HUDExtrasPreDrawFPS`
 
 **Purpose**
@@ -272,3 +274,4 @@ hook.Add("HUDExtrasPostDrawWatermark", "ResetWatermarkColor", function()
     surface.SetDrawColor(255, 255, 255)
 end)
 ```
+---

--- a/instakill/docs/hooks.md
+++ b/instakill/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Instakill module.
 
+---
 ### `ShouldInstantKill`
 
 **Purpose**
@@ -75,3 +77,4 @@ hook.Add("PlayerInstantKilled", "OnKill", function(ply, dmginfo)
     print(ply:Nick() .. " was instantly killed")
 end)
 ```
+---

--- a/inventory/docs/hooks.md
+++ b/inventory/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Inventory module.
 
+---
 ### `InventoryPrePlayerLoadedChar`
 
 **Purpose**
@@ -281,3 +283,4 @@ hook.Add("WeightInvItemRemoved", "OnRemove", function(inv, item)
     print(item.name .. " removed")
 end)
 ```
+---

--- a/joinleavemessages/docs/hooks.md
+++ b/joinleavemessages/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Joinleavemessages module.
 
+---
 ### `PreJoinLeaveMessageSent`
 
 **Purpose**
@@ -51,3 +53,4 @@ hook.Add("JoinLeaveMessageSent", "LogToConsole", function(ply, joined, msg)
     print(msg)
 end)
 ```
+---

--- a/loadmessages/docs/hooks.md
+++ b/loadmessages/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Loadmessages module.
 
+---
 ### `PreLoadMessage`
 
 **Purpose**
@@ -96,3 +98,4 @@ hook.Add("LoadMessageMissing", "FallbackMessage", function(client)
     client:ChatPrint("Welcome back!")
 end)
 ```
+---

--- a/loyalism/docs/hooks.md
+++ b/loyalism/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Loyalism module.
 
+---
 ### `PreUpdatePartyTiers`
 
 **Purpose**
@@ -119,3 +121,4 @@ hook.Add("PostUpdatePartyTiers", "Done", function()
     print("Tiers updated")
 end)
 ```
+---

--- a/mapcleaner/docs/hooks.md
+++ b/mapcleaner/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Mapcleaner module.
 
+---
 ### `PreItemCleanupWarning`
 
 **Purpose**
@@ -237,3 +239,4 @@ hook.Add("PostMapCleanup", "CleanupDone", function()
     print("Map cleanup completed")
 end)
 ```
+---

--- a/modelpay/docs/hooks.md
+++ b/modelpay/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Modelpay module.
 
+---
 ### `ModelPayModelChecked`
 
 **Purpose**
@@ -172,3 +174,4 @@ hook.Add("ModelPayModelIneligible", "StopSalary", function(client, model)
     -- cleanup
 end)
 ```
+---

--- a/modeltweaker/docs/hooks.md
+++ b/modeltweaker/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Modeltweaker module.
 
+---
 ### `WardrobeModelChangeRequested`
 
 **Purpose**
@@ -122,3 +124,4 @@ hook.Add("WardrobeModelInvalid", "Warn", function(client, newModel)
     print(newModel, "is not permitted")
 end)
 ```
+---

--- a/npcdrop/docs/hooks.md
+++ b/npcdrop/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Npcdrop module.
 
+---
 ### `NPCDropCheck`
 
 **Purpose**
@@ -144,3 +146,4 @@ hook.Add("NPCDropFailed", "Failure", function(ent)
     print("No item chosen for", ent:GetClass())
 end)
 ```
+---

--- a/npcspawner/docs/hooks.md
+++ b/npcspawner/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Npcspawner module.
 
+---
 ### `CanNPCSpawn`
 
 **Purpose**
@@ -261,3 +263,4 @@ hook.Add("OnNPCForceSpawn", "LogForce", function(client, spawnerName)
     print(client:Name(), "forced spawn", spawnerName)
 end)
 ```
+---

--- a/permaremove/docs/hooks.md
+++ b/permaremove/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Permaremove module.
 
+---
 ### `CanPermaRemoveEntity`
 
 **Purpose**
@@ -74,3 +76,4 @@ hook.Add("OnPermaRemoveLoaded", "HandleLoadedRemoval", function(entity)
     print("Removed on load", entity)
 end)
 ```
+---

--- a/radio/docs/hooks.md
+++ b/radio/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Radio module.
 
+---
 ### `AddSection`
 
 **Purpose**
@@ -316,3 +318,4 @@ hook.Add("RefreshFonts", "ReloadRadioFonts", function()
     print("Updating radio fonts")
 end)
 ```
+---

--- a/raisedweapons/docs/hooks.md
+++ b/raisedweapons/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Raisedweapons module.
 
+---
 ### `OverrideWeaponRaiseSpeed`
 
 **Purpose**
@@ -205,3 +207,4 @@ hook.Add("OnWeaponLowered", "AlertLowered", function(player, weapon)
     print(player:Name(), "lowered", weapon:GetClass())
 end)
 ```
+---

--- a/raisedweapons/docs/meta.md
+++ b/raisedweapons/docs/meta.md
@@ -1,5 +1,8 @@
-# Meta
+# Player Meta
 
+Utility methods for managing the raised state of a player's weapon.
+
+---
 ### Player:isWepRaised (Shared)
 
 **Purpose**
@@ -69,3 +72,4 @@ Server
 ```lua
 client:toggleWepRaised()
 ```
+---

--- a/realisticdamage/docs/hooks.md
+++ b/realisticdamage/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Realisticdamage module.
 
+---
 ### `PreScaleDamage`
 
 **Purpose**
@@ -208,3 +210,4 @@ hook.Add("OnPainSoundPlayed", "LogPain", function(ply, path)
     print("Played pain sound", path)
 end)
 ```
+---

--- a/realisticview/docs/hooks.md
+++ b/realisticview/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Realisticview module.
 
+---
 ### `ShouldUseRealisticView`
 
 **Purpose**
@@ -76,3 +78,4 @@ hook.Add("RealisticViewCalcView", "AddRoll", function(client, view)
     view.angles.r = view.angles.r + 5
 end)
 ```
+---

--- a/rumour/docs/hooks.md
+++ b/rumour/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Rumour module.
 
+---
 ### `CanSendRumour`
 
 **Purpose**
@@ -236,3 +238,4 @@ hook.Add("RumourRevealed", "Embarrass", function(client)
 end)
 ```
 
+---

--- a/shootlock/docs/hooks.md
+++ b/shootlock/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Shootlock module.
 
+---
 ### `LockShotAttempt`
 
 **Purpose**
@@ -132,3 +134,4 @@ hook.Add("LockShotFailed", "BreachFailed", function(client, door)
     client:notify("The lock held strong.")
 end)
 ```
+---

--- a/simple_lockpicking/docs/hooks.md
+++ b/simple_lockpicking/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the SimpleLockpicking module.
 
+---
 ### `CanPlayerLockpick`
 
 **Purpose**
@@ -132,3 +134,4 @@ hook.Add("LockpickInterrupted", "HandleAbort", function(client, target)
     client:notify("Lockpicking stopped")
 end)
 ```
+---

--- a/slots/docs/hooks.md
+++ b/slots/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Slots module.
 
+---
 ### `SlotMachineUse`
 
 **Purpose**
@@ -105,3 +107,4 @@ hook.Add("SlotMachineEnd", "ReadyAgain", function(machine, client)
     machine.IsPlaying = true
 end)
 ```
+---

--- a/slowweapons/docs/hooks.md
+++ b/slowweapons/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Slowweapons module.
 
+---
 ### `OverrideSlowWeaponSpeed`
 
 **Purpose**
@@ -86,3 +88,4 @@ hook.Add("PostApplyWeaponSlowdown", "NotifySlowdown", function(client, weapon, m
     end
 end)
 ```
+---

--- a/stungun/docs/hooks.md
+++ b/stungun/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Stungun module.
 
+---
 ### `PlayerStunned`
 
 **Purpose**
@@ -206,3 +208,4 @@ hook.Add("StunGunTethered", "TetherMsg", function(owner, target)
     owner:ChatPrint("Tethered to " .. target:Name())
 end)
 ```
+---

--- a/tying/docs/hooks.md
+++ b/tying/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Tying module.
 
+---
 ### `PlayerStartUnTying`
 
 **Purpose**
@@ -175,3 +177,4 @@ hook.Add("PlayerUnhandcuffed", "FreedomMsg", function(target)
     target:ChatPrint("You are free to go.")
 end)
 ```
+---

--- a/tying/docs/meta.md
+++ b/tying/docs/meta.md
@@ -1,5 +1,8 @@
-# Meta
+# Player Meta
 
+Convenience helpers for playing handcuff animations.
+
+---
 ### Player:StartHandcuffAnim (Server)
 
 **Purpose**
@@ -49,3 +52,4 @@ Server
 ```lua
 client:EndHandcuffAnim()
 ```
+---

--- a/utilities/docs/hooks.md
+++ b/utilities/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Utilities module.
 
+---
 ### `CodeUtilsLoaded`
 
 **Purpose**
@@ -70,3 +72,4 @@ hook.Add("UtilityEntitySpawned", "TrackEntity", function(entity, class, position
     print("Spawned entity", class)
 end)
 ```
+---

--- a/utilities/docs/libraries.md
+++ b/utilities/docs/libraries.md
@@ -1,5 +1,3 @@
-# Libraries
-
 # Utilities Library
 
 This page documents the helper functions defined in **`lia.utilities`** and the small core-Lua extensions shipped alongside them.

--- a/utilities/docs/meta.md
+++ b/utilities/docs/meta.md
@@ -1,5 +1,8 @@
-# Meta
+# Utility Meta
 
+A collection of player and entity utility helpers.
+
+---
 ### Player:squaredDistanceFromEnt (Shared)
 
 **Purpose**
@@ -227,3 +230,4 @@ Shared
 **Returns**
 
 *boolean*
+---

--- a/viewbob/docs/hooks.md
+++ b/viewbob/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Viewbob module.
 
+---
 ### `ViewBobPunch`
 
 **Purpose**
@@ -112,3 +114,4 @@ hook.Add("PostViewPunch", "PostEffects", function(client)
 end)
 ```
 
+---

--- a/vmanip/docs/hooks.md
+++ b/vmanip/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Vmanip module.
 
+---
 ### `PreVManipPickup`
 
 **Purpose**
@@ -51,3 +53,4 @@ hook.Add("VManipPickup", "PlaySound", function(client, item)
     client:EmitSound("items/ammo_pickup.wav")
 end)
 ```
+---

--- a/warrants/docs/hooks.md
+++ b/warrants/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Warrants module.
 
+---
 ### `PreWarrantToggle`
 
 **Purpose**
@@ -82,3 +84,4 @@ hook.Add("PostWarrantToggle", "Cleanup", function(char, actor, warranted)
     end
 end)
 ```
+---

--- a/warrants/docs/meta.md
+++ b/warrants/docs/meta.md
@@ -1,5 +1,8 @@
-# Meta
+# Character Meta
 
+Extensions for managing a character's warrant status.
+
+---
 ### Character:ToggleWanted (Server)
 
 **Purpose**
@@ -97,3 +100,4 @@ Server
 **Returns**
 
 *boolean*
+---

--- a/wartable/docs/hooks.md
+++ b/wartable/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Wartable module.
 
+---
 ### `PreWarTableClear`
 
 **Purpose**
@@ -401,3 +403,4 @@ hook.Add("PostWarTableUsed", "Example_PostWarTableUsed", function(activator, tab
 end)
 ```
 
+---

--- a/whitelist/docs/hooks.md
+++ b/whitelist/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Whitelist module.
 
+---
 ### `PreWhitelistCheck`
 
 **Purpose**
@@ -128,3 +130,4 @@ hook.Add("PostWhitelistCheck", "Example_PostWhitelistCheck", function(steamID64,
 end)
 ```
 
+---

--- a/wordfilter/docs/hooks.md
+++ b/wordfilter/docs/hooks.md
@@ -1,5 +1,7 @@
 # Hooks
+Module-specific events raised by the Wordfilter module.
 
+---
 ### `PreFilterCheck`
 
 **Purpose**
@@ -184,3 +186,4 @@ hook.Add("WordRemovedFromFilter", "AnnounceRemove", function(word)
 end)
 ```
 
+---


### PR DESCRIPTION
## Summary
- add introductory text to hooks documentation
- clarify meta documentation with section headers
- remove redundant prefix from libraries docs

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_6877fd5528c083278a6dade2ca0742f6