### PR TITLE
Fix docs line breaks

### DIFF
--- a/sampledocs/hooks.md
+++ b/sampledocs/hooks.md
@@ -180,6 +180,7 @@ Fires when a player is moved into this class from another.
 **Parameters**
 
 * `client` (`Player`): The player who was transferred.
+
 * `oldClass` (`number`): Index of the previous class.
 
 **Realm**
@@ -206,3 +207,4 @@ end
 ```
 
 ---
+

--- a/sampledocs/libraries.md
+++ b/sampledocs/libraries.md
@@ -77,3 +77,4 @@ lia.attribs.setup(client)
 ```
 
 ---
+

--- a/sampledocs/meta.md
+++ b/sampledocs/meta.md
@@ -928,3 +928,4 @@ client:resetParts()
 ```
 
 ---
+


### PR DESCRIPTION
## Summary
- insert missing blank lines after bullet entries
- ensure documentation files end with newline

## Testing
- `python - <<'PY'
import os, re
issues=[]
for root, dirs, files in os.walk('.'):
    if root.endswith('docs'):
        for f in files:
            if f.endswith('.md'):
                path=os.path.join(root,f)
                with open(path) as fh:
                    lines=fh.read().splitlines()
                in_code=False
                for i, line in enumerate(lines[:-1]):
                    if line.strip().startswith('```'):
                        in_code = not in_code
                    if in_code:
                        continue
                    if line.strip() and lines[i+1].strip():
                        issues.append((path, i+1, line))
                if lines and lines[-1].strip():
                    issues.append((path, len(lines), lines[-1]))
print('Total issues:', len(issues))
PY


------
https://chatgpt.com/codex/tasks/task_e_687a7f1f30708327898083c0eacdae70