### PR TITLE
Fix extended description menu action

### DIFF
--- a/extendeddescriptions/pim/shared.lua
+++ b/extendeddescriptions/pim/shared.lua
@@ -1,7 +1,8 @@
-﻿AddInteraction(L("openDetDescLabel"), {
-    runServer = false,
+AddInteraction(L("openDetDescLabel"), {
+    runServer = true,
     shouldShow = function(_, target) return IsValid(target) end,
     onRun = function(client, target)
+        if not SERVER then return end
         net.Start("OpenDetailedDescriptions")
         net.WriteEntity(target)
         net.WriteString(target:getChar():getData("textDetDescData", nil) or L("openDetDescFallback"))


### PR DESCRIPTION
## Summary
- run the extended description interaction on the server
- guard the handler so it only runs serverside

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687abce8f0348327b3598e357e3b8d43