### PR TITLE
Use module names for docs folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,9 +222,15 @@ jobs:
           for d in extracted_*; do
             [ -d "$d" ] || continue
             mod=${d#extracted_}
+            name=$(jq -r --arg id "$mod" '.[] | select(.public_uniqueID==$id) | .name' documentation/modules.json || echo '')
+            if [ -n "$name" ]; then
+              folder=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g' | sed -E 's/^_+|_+$//g')
+            else
+              folder="$mod"
+            fi
             doc_dir=$(find "$d" -type d -iname docs -maxdepth 2 -print -quit || true)
             [ -z "$doc_dir" ] && continue
-            dest="documentation/docs/modules/${mod}"
+            dest="documentation/docs/modules/${folder}"
             mkdir -p "$dest"
             find "$doc_dir" -maxdepth 1 -type f -name '*.md' -exec cp {} "$dest/" \;
           done

--- a/generate_about_md.js
+++ b/generate_about_md.js
@@ -19,11 +19,20 @@ try {
 }
 if (!Array.isArray(modules)) process.exit(1)
 
+function toFolderName(name) {
+  return String(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+}
+
 for (const mod of modules) {
   const id = mod.public_uniqueID || ''
   if (!id) continue
 
-  const outputDir = path.join(__dirname, 'documentation', 'docs', 'modules', id)
+  const folder = toFolderName(mod.name || id)
+
+  const outputDir = path.join(__dirname, 'documentation', 'docs', 'modules', folder)
   fs.mkdirSync(outputDir, { recursive: true })
 
   const lines = []


### PR DESCRIPTION
## Summary
- slugify module names when generating about docs
- look up module name when copying docs in the workflow

## Testing
- `node --check generate_about_md.js`


------
https://chatgpt.com/codex/tasks/task_e_687bfe210110832790cb16df990ea83b