### PR TITLE
Fix line break after description in about generator

### DIFF
--- a/generate_about_md.js
+++ b/generate_about_md.js
@@ -46,6 +46,7 @@ for (const mod of modules) {
   lines.push(mod.version || '')
   lines.push('')
   lines.push('**Description:**')
+  lines.push('')
   lines.push(mod.description || '')
   lines.push('')
 


### PR DESCRIPTION
## Summary
- ensure a blank line is inserted between the description label and text when generating about.md

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687bff4f612083279b0d6640456b6ef5