### PR TITLE
Fix inconsistent module names

### DIFF
--- a/advert/docs/hooks.md
+++ b/advert/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Advert module.
+Module-specific events raised by the Advertisements module.
 
 ---
 

--- a/advert/module.lua
+++ b/advert/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Advert"
+﻿MODULE.name = "Advertisements"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.16

--- a/bodygrouper/docs/hooks.md
+++ b/bodygrouper/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Bodygrouper module.
+Module-specific events raised by the Bodygroup Editor module.
 
 ---
 

--- a/bodygrouper/languages/english.lua
+++ b/bodygrouper/languages/english.lua
@@ -11,5 +11,5 @@ LANGUAGE = {
     rotateInstruction = "Hold R to rotate the model.",
     skin = "Skin",
     viewBodygroupsDesc = "View or edit a player's bodygroups.",
-    bodygrouper = "Bodygrouper",
+    bodygrouper = "Bodygroup Editor",
 }

--- a/bodygrouper/module.lua
+++ b/bodygrouper/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Bodygrouper"
+﻿MODULE.name = "Bodygroup Editor"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.22

--- a/corpseid/docs/hooks.md
+++ b/corpseid/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Corpseid module.
+Module-specific events raised by the Corpse Identification module.
 
 ---
 

--- a/corpseid/module.lua
+++ b/corpseid/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Corpse ID"
+﻿MODULE.name = "Corpse Identification"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/cursor/docs/hooks.md
+++ b/cursor/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Cursor module.
+Module-specific events raised by the Custom Cursor module.
 
 ---
 

--- a/cursor/module.lua
+++ b/cursor/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Cursor"
+﻿MODULE.name = "Custom Cursor"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.13

--- a/donator/docs/hooks.md
+++ b/donator/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Donator module.
+Module-specific events raised by the Donator Perks module.
 
 ---
 

--- a/donator/module.lua
+++ b/donator/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Donator"
+﻿MODULE.name = "Donator Perks"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.23

--- a/enhanceddeath/docs/hooks.md
+++ b/enhanceddeath/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Enhanceddeath module.
+Module-specific events raised by the Hospital Respawn module.
 
 ---
 

--- a/enhanceddeath/module.lua
+++ b/enhanceddeath/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Hospitals"
+﻿MODULE.name = "Hospital Respawn"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.12

--- a/gamemasterpoints/docs/hooks.md
+++ b/gamemasterpoints/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Gamemasterpoints module.
+Module-specific events raised by the Gamemaster Points module.
 
 ---
 

--- a/gamemasterpoints/module.lua
+++ b/gamemasterpoints/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Gamemaster Teleport Points"
+﻿MODULE.name = "Gamemaster Points"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.13

--- a/hud_extras/docs/hooks.md
+++ b/hud_extras/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the HudExtras module.
+Module-specific events raised by the HUD Extras module.
 
 ---
 

--- a/hud_extras/module.lua
+++ b/hud_extras/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Extra HUD Elements"
+﻿MODULE.name = "HUD Extras"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.18

--- a/instakill/docs/hooks.md
+++ b/instakill/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Instakill module.
+Module-specific events raised by the Instant Kill module.
 
 ---
 

--- a/instakill/module.lua
+++ b/instakill/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Instant Killing"
+﻿MODULE.name = "Instant Kill"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.15

--- a/inventory/docs/hooks.md
+++ b/inventory/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Inventory module.
+Module-specific events raised by the Weighted Inventory module.
 
 ---
 

--- a/inventory/module.lua
+++ b/inventory/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Weight Inv"
+﻿MODULE.name = "Weighted Inventory"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.15

--- a/inventory/submodules/storage/module.lua
+++ b/inventory/submodules/storage/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Storage"
+﻿MODULE.name = "Storage Containers"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.06

--- a/inventory/submodules/vendor/module.lua
+++ b/inventory/submodules/vendor/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Vendors"
+﻿MODULE.name = "Item Vendors"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.04

--- a/rumour/docs/hooks.md
+++ b/rumour/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Rumour module.
+Module-specific events raised by the Anonymous Rumors module.
 
 ---
 

--- a/rumour/module.lua
+++ b/rumour/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Rumour"
+﻿MODULE.name = "Anonymous Rumors"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.14

--- a/slots/docs/hooks.md
+++ b/slots/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Slots module.
+Module-specific events raised by the Slot Machine module.
 
 ---
 

--- a/slots/module.lua
+++ b/slots/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Slots"
+﻿MODULE.name = "Slot Machine"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.15

--- a/slowweapons/docs/hooks.md
+++ b/slowweapons/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Slowweapons module.
+Module-specific events raised by the Heavy Weapon Slowdown module.
 
 ---
 

--- a/slowweapons/module.lua
+++ b/slowweapons/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Heavy Weapons"
+﻿MODULE.name = "Heavy Weapon Slowdown"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.14

--- a/tying/submodules/tyingsearch/module.lua
+++ b/tying/submodules/tyingsearch/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Search Tying Sub-Module"
+﻿MODULE.name = "Search Tied Players"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.03

--- a/utilities/docs/hooks.md
+++ b/utilities/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Utilities module.
+Module-specific events raised by the Code Utilities module.
 
 ---
 

--- a/utilities/module.lua
+++ b/utilities/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Code Utils"
+﻿MODULE.name = "Code Utilities"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.20

--- a/viewbob/docs/hooks.md
+++ b/viewbob/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Viewbob module.
+Module-specific events raised by the View Bobbing module.
 
 ---
 

--- a/viewbob/module.lua
+++ b/viewbob/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "View Bob"
+﻿MODULE.name = "View Bobbing"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.15

--- a/vmanip/docs/hooks.md
+++ b/vmanip/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Vmanip module.
+Module-specific events raised by the Viewmodel Animations module.
 
 ---
 

--- a/vmanip/module.lua
+++ b/vmanip/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "VManip"
+﻿MODULE.name = "Viewmodel Animations"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.16

--- a/warrants/docs/hooks.md
+++ b/warrants/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Warrants module.
+Module-specific events raised by the Warrant System module.
 
 ---
 

--- a/warrants/module.lua
+++ b/warrants/module.lua
@@ -1,4 +1,4 @@
-﻿MODULE.name = "Warrant"
+﻿MODULE.name = "Warrant System"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.24


### PR DESCRIPTION
## Summary
- clarify module names in documentation to match new titles

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687bfe82f88083278074cc266783ac12