### PR TITLE
Fix nil minFPS in HUD extras

### DIFF
--- a/hud_extras/libraries/client.lua
+++ b/hud_extras/libraries/client.lua
@@ -6,8 +6,10 @@ local function DrawFPS()
     hook.Run("HUDExtrasPreDrawFPS")
     local fpsFont = lia.config.get("FPSHudFont")
     local f = math.Round(1 / FrameTime())
-    local minF = MODULE.minFPS or 60
-    local maxF = MODULE.maxFPS or 100
+    MODULE.minFPS = MODULE.minFPS or 60
+    local minF = MODULE.minFPS
+    MODULE.maxFPS = MODULE.maxFPS or 100
+    local maxF = MODULE.maxFPS
     MODULE.barH = MODULE.barH or 1
     MODULE.barH = mathApproach(MODULE.barH, f / maxF * 100, 0.5)
     if f > maxF then MODULE.maxFPS = f end


### PR DESCRIPTION
## Summary
- prevent nil value in HUD extras' FPS display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880ce071c94832798fd335edc7d80e9