### PR TITLE
Move character variable definitions into modules

### DIFF
--- a/extendeddescriptions/commands.lua
+++ b/extendeddescriptions/commands.lua
@@ -4,8 +4,9 @@
     onRun = function(client)
         net.Start("OpenDetailedDescriptions")
         net.WriteEntity(client)
-        net.WriteString(client:getChar():getData("textDetDescData", nil) or L("openDetDescFallback"))
-        net.WriteString(client:getChar():getData("textDetDescDataURL", nil) or L("openDetDescFallback"))
+        local char = client:getChar()
+        net.WriteString(char:getTextDetDescData() or L("openDetDescFallback"))
+        net.WriteString(char:getTextDetDescDataURL() or L("openDetDescFallback"))
         net.Send(client)
     end
 })

--- a/extendeddescriptions/libraries/shared.lua
+++ b/extendeddescriptions/libraries/shared.lua
@@ -1,0 +1,13 @@
+lia.char.registerVar("textDetDescData", {
+    field = "text_det_desc_data",
+    fieldType = "text",
+    default = {},
+    noDisplay = true,
+})
+
+lia.char.registerVar("textDetDescDataURL", {
+    field = "text_det_desc_data_url",
+    fieldType = "text",
+    default = {},
+    noDisplay = true,
+})

--- a/extendeddescriptions/netcalls/client.lua
+++ b/extendeddescriptions/netcalls/client.lua
@@ -33,12 +33,12 @@ net.Receive("SetDetailedDescriptions", function()
     textEntry:Dock(FILL)
     textEntry:SetMultiline(true)
     textEntry:SetVerticalScrollbarEnabled(true)
-    local prevDesc = LocalPlayer():getChar():getData("textDetDescData")
+    local prevDesc = LocalPlayer():getChar():getTextDetDescData()
     if prevDesc then textEntry:SetText(prevDesc) end
     local urlEntry = vgui.Create("DTextEntry", frame)
     urlEntry:Dock(BOTTOM)
     urlEntry:SetTall(30)
-    local prevURL = LocalPlayer():getChar():getData("textDetDescDataURL")
+    local prevURL = LocalPlayer():getChar():getTextDetDescDataURL()
     if prevURL then
         urlEntry:SetText(prevURL)
     else

--- a/extendeddescriptions/netcalls/server.lua
+++ b/extendeddescriptions/netcalls/server.lua
@@ -5,8 +5,9 @@
     for _, client in player.Iterator() do
         if client:SteamName() == callingClientSteamName then
             hook.Run("PreExtendedDescriptionUpdate", client, textEntryURL, text)
-            client:getChar():setData("textDetDescData", text)
-            client:getChar():setData("textDetDescDataURL", textEntryURL)
+            local char = client:getChar()
+            char:setTextDetDescData(text)
+            char:setTextDetDescDataURL(textEntryURL)
             hook.Run("ExtendedDescriptionUpdated", client, textEntryURL, text)
         end
     end

--- a/extendeddescriptions/pim/shared.lua
+++ b/extendeddescriptions/pim/shared.lua
@@ -5,8 +5,9 @@ AddInteraction(L("openDetDescLabel"), {
         if not SERVER then return end
         net.Start("OpenDetailedDescriptions")
         net.WriteEntity(target)
-        net.WriteString(target:getChar():getData("textDetDescData", nil) or L("openDetDescFallback"))
-        net.WriteString(target:getChar():getData("textDetDescDataURL", nil) or L("openDetDescFallback"))
+        local char = target:getChar()
+        net.WriteString(char:getTextDetDescData() or L("openDetDescFallback"))
+        net.WriteString(char:getTextDetDescDataURL() or L("openDetDescFallback"))
         net.Send(client)
     end
 })

--- a/loyalism/commands.lua
+++ b/loyalism/commands.lua
@@ -33,7 +33,7 @@ lia.command.add("partytier", {
         if tier > #MODULE.Tiers then tier = 10 end
         local tChar = target:getChar()
         if tChar then
-            tChar:setData("party_tier", tier, false, player.GetAll())
+            tChar:setPartyTier(tier)
             client:notifyLocalized("partyTierUpdated", target:Name(), tier)
             if tier == 0 then
                 target:notifyLocalized("partyTierRemoved", client:Name())

--- a/loyalism/libraries/client.lua
+++ b/loyalism/libraries/client.lua
@@ -1,17 +1,17 @@
 ﻿local MODULE = MODULE
 function MODULE:DrawCharInfo(_, character, info)
-    local tier = tonumber(character:getData("party_tier", 0))
+    local tier = tonumber(character:getPartyTier())
     if self.Tiers[tier] then info[#info + 1] = {self.Tiers[tier], Color(255, 209, 20)} end
 end
 
 function MODULE:LoadCharInformation()
     local client = LocalPlayer()
     local character = client:getChar()
-    local tier = tonumber(character:getData("party_tier", 0))
+    local tier = tonumber(character:getPartyTier())
     hook.Run("AddTextField", L("generalinfo"), "partytier", L("partyTier"), function() return self.Tiers[tier] end)
 end
 
 function MODULE:LoadMainMenuInformation(info, character)
-    local tier = tonumber(character:getData("party_tier", 0))
+    local tier = tonumber(character:getPartyTier())
     table.insert(info, L("partyTierDisplay", self.Tiers[tier]))
 end

--- a/loyalism/libraries/server.lua
+++ b/loyalism/libraries/server.lua
@@ -8,9 +8,9 @@ function MODULE:UpdatePartyTiers()
     for _, ply in player.Iterator() do
         local char = ply:getChar()
         if char then
-            local tier = char:getData("party_tier", 0)
+            local tier = char:getPartyTier()
             hook.Run("PartyTierApplying", ply, tier)
-            char:setData("party_tier", tier, false, player.GetAll())
+            char:setPartyTier(tier)
             hook.Run("PartyTierUpdated", ply, tier)
         else
             hook.Run("PartyTierNoCharacter", ply)

--- a/loyalism/libraries/shared.lua
+++ b/loyalism/libraries/shared.lua
@@ -1,0 +1,6 @@
+lia.char.registerVar("partyTier", {
+    field = "party_tier",
+    fieldType = "integer",
+    default = 0,
+    noDisplay = true,
+})

--- a/warrants/libraries/client.lua
+++ b/warrants/libraries/client.lua
@@ -6,13 +6,13 @@ end
 function MODULE:LoadCharInformation()
     hook.Run("AddTextField", L("generalinfo"), "wanted", L("wanted"), function()
         local character = LocalPlayer():getChar()
-        if character and character.getData and character:getData("wanted", false) then return L("wanted") end
+        if character and character.getWanted and character:getWanted() then return L("wanted") end
         return L("upstanding")
     end)
 end
 
 function MODULE:LoadMainMenuInformation(info, character)
-    if character:getData("wanted", false) then
+    if character:getWanted() then
         table.insert(info, L("reputation") .. ": " .. L("wanted"))
     else
         table.insert(info, L("reputation") .. ": " .. L("upstanding"))

--- a/warrants/libraries/shared.lua
+++ b/warrants/libraries/shared.lua
@@ -1,0 +1,6 @@
+lia.char.registerVar("wanted", {
+    field = "wanted",
+    fieldType = "integer",
+    default = false,
+    noDisplay = true,
+})

--- a/warrants/meta/sh_player.lua
+++ b/warrants/meta/sh_player.lua
@@ -3,7 +3,7 @@ if SERVER then
     function characterMeta:ToggleWanted(warranter)
         local warranted = not self:IsWanted()
         hook.Run("PreWarrantToggle", self, warranter, warranted)
-        self:setData("wanted", warranted)
+        self:setWanted(warranted)
         hook.Run("WarrantStatusChanged", self, warranter, warranted)
         local notificationMessage = warranted and L("WarrantIssued") or L("WarrantRemoved")
         self:notify(notificationMessage)
@@ -34,7 +34,7 @@ if SERVER then
     end
 
     function characterMeta:IsWanted()
-        return self:getData("wanted", false)
+        return self:getWanted()
     end
 
     function characterMeta:CanSeeWarrants()


### PR DESCRIPTION
## Summary
- move new character variable registrations from `character.lua` to their respective modules
- use new character accessors throughout modules

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68819e41d5c88327a597c8b3371a61bc