### PR TITLE
Add categories to privilege definitions

### DIFF
--- a/bodygrouper/module.lua
+++ b/bodygrouper/module.lua
@@ -9,9 +9,11 @@ MODULE.Privileges = {
     {
         Name = "Manage Bodygroups",
         MinAccess = "admin",
+        Category = "Bodygroups",
     },
     {
         Name = "Change Bodygroups",
         MinAccess = "admin",
+        Category = "Bodygroups",
     }
 }

--- a/broadcasts/module.lua
+++ b/broadcasts/module.lua
@@ -14,10 +14,12 @@ MODULE.Privileges = {
     {
         Name = "Can Use Faction Broadcast",
         MinAccess = "superadmin",
+        Category = "Broadcasts",
     },
     {
         Name = "Can Use Class Broadcast",
         MinAccess = "superadmin",
+        Category = "Broadcasts",
     }
 }
 

--- a/cinematictext/module.lua
+++ b/cinematictext/module.lua
@@ -9,9 +9,11 @@ MODULE.Privileges = {
     {
         Name = "Use Cinematic Menu",
         MinAccess = "admin",
+        Category = "Cinematics",
     },
     {
         Name = "Use Cinematic Menu",
         MinAccess = "admin",
+        Category = "Cinematics",
     }
 }

--- a/cutscenes/module.lua
+++ b/cutscenes/module.lua
@@ -10,5 +10,6 @@ MODULE.Privileges = {
     {
         Name = "Use Cutscenes",
         MinAccess = "admin",
+        Category = "Cutscenes",
     },
 }

--- a/developmenthud/module.lua
+++ b/developmenthud/module.lua
@@ -7,10 +7,12 @@ MODULE.Privileges = {
     {
         Name = "Staff HUD",
         MinAccess = "superadmin",
+        Category = "Development HUD",
     },
     {
         Name = "Development HUD",
         MinAccess = "superadmin",
+        Category = "Development HUD",
     }
 }
 

--- a/donator/module.lua
+++ b/donator/module.lua
@@ -14,13 +14,16 @@ MODULE.Privileges = {
     {
         Name = "Subtract CharSlots",
         MinAccess = "superadmin",
+        Category = "Character Slots",
     },
     {
         Name = "Add CharSlots",
         MinAccess = "superadmin",
+        Category = "Character Slots",
     },
     {
         Name = "Set CharSlots",
         MinAccess = "superadmin",
+        Category = "Character Slots",
     }
 }

--- a/extendeddescriptions/module.lua
+++ b/extendeddescriptions/module.lua
@@ -9,5 +9,6 @@ MODULE.Privileges = {
     {
         Name = "Change Description",
         MinAccess = "admin",
+        Category = "Descriptions",
     }
 }

--- a/gamemasterpoints/module.lua
+++ b/gamemasterpoints/module.lua
@@ -9,5 +9,6 @@ MODULE.Privileges = {
     {
         Name = "Manage Gamemaster Teleport Points",
         MinAccess = "admin",
+        Category = "Gamemaster Points",
     }
 }

--- a/inventory/module.lua
+++ b/inventory/module.lua
@@ -28,5 +28,6 @@ MODULE.Privileges = {
     {
         Name = "Set Inventory Weight",
         MinAccess = "admin",
+        Category = "Inventory",
     }
 }

--- a/inventory/submodules/storage/module.lua
+++ b/inventory/submodules/storage/module.lua
@@ -7,10 +7,12 @@ MODULE.Privileges = {
     {
         Name = "Can Spawn Storage",
         MinAccess = "superadmin",
+        Category = "Storage",
     },
     {
         Name = "Lock Storage",
         MinAccess = "admin",
+        Category = "Storage",
     }
 }
 

--- a/inventory/submodules/vendor/module.lua
+++ b/inventory/submodules/vendor/module.lua
@@ -8,9 +8,11 @@ MODULE.Privileges = {
     {
         Name = "Can Edit Vendors",
         MinAccess = "admin",
+        Category = "Vendors",
     },
     {
         Name = "Manage Vendors",
         MinAccess = "superadmin",
+        Category = "Vendors",
     },
 }

--- a/loyalism/module.lua
+++ b/loyalism/module.lua
@@ -10,5 +10,6 @@ MODULE.Privileges = {
     {
         Name = "Management - Assign Party Tiers",
         MinAccess = "admin",
+        Category = "Loyalism",
     }
 }

--- a/npcspawner/module.lua
+++ b/npcspawner/module.lua
@@ -14,5 +14,6 @@ MODULE.Privileges = {
     {
         Name = "Force NPC Spawn",
         MinAccess = "superadmin",
+        Category = "Spawn Permissions",
     }
 }

--- a/permaremove/module.lua
+++ b/permaremove/module.lua
@@ -9,5 +9,6 @@ MODULE.Privileges = {
     {
         Name = "Remove Map Entities",
         MinAccess = "admin",
+        Category = "Map Cleanup",
     }
 }

--- a/warrants/module.lua
+++ b/warrants/module.lua
@@ -9,13 +9,16 @@ MODULE.Privileges = {
     {
         Name = "Can Warrant People",
         MinAccess = "superadmin",
+        Category = "Warrants",
     },
     {
         Name = "Can See Warrants",
         MinAccess = "superadmin",
+        Category = "Warrants",
     },
     {
         Name = "Can See Warrant Notifications",
         MinAccess = "superadmin",
+        Category = "Warrants",
     },
 }


### PR DESCRIPTION
## Summary
- add administrative categories to privilege definitions across modules

## Testing
- `luacheck bodygrouper/module.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688ec36a4ee08327a030af2042adc3ed