### PR TITLE
Localize module metadata in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,10 +134,17 @@ jobs:
           for m in */module.lua; do
             [ -f "$m" ] || continue
             dir=${m%%/*}
-            name=$(grep -Po 'MODULE\.name\s*=\s*"[^"]*"' "$m" | sed -E 's/.*=\s*"([^"]+)".*/\1/' || true)
-            author=$(grep -Po 'MODULE\.author\s*=\s*"[^"]*"' "$m" | sed -E 's/.*=\s*"([^"]+)".*/\1/' || true)
-            discord=$(grep -Po 'MODULE\.discord\s*=\s*"[^"]*"' "$m" | sed -E 's/.*=\s*"([^"]+)".*/\1/' || true)
-            desc=$(grep -Po 'MODULE\.desc\s*=\s*"[^"]*"' "$m" | sed -E 's/.*=\s*"([^"]+)".*/\1/' || true)
+              name_key=$(grep -Po 'MODULE\.name\s*=\s*"[^"]*"' "$m" | sed -E 's/.*=\s*"([^"]+)".*/\1/' || true)
+              author=$(grep -Po 'MODULE\.author\s*=\s*"[^"]*"' "$m" | sed -E 's/.*=\s*"([^"]+)".*/\1/' || true)
+              discord=$(grep -Po 'MODULE\.discord\s*=\s*"[^"]*"' "$m" | sed -E 's/.*=\s*"([^"]+)".*/\1/' || true)
+              desc_key=$(grep -Po 'MODULE\.desc\s*=\s*"[^"]*"' "$m" | sed -E 's/.*=\s*"([^"]+)".*/\1/' || true)
+              lang_file="$dir/languages/english.lua"
+              if [ -f "$lang_file" ]; then
+                name=$(grep -Po "\\b${name_key}\\s*=\\s*\"\K[^\"]*" "$lang_file" | head -n1 || true)
+                desc=$(grep -Po "\\b${desc_key}\\s*=\\s*\"\K[^\"]*" "$lang_file" | head -n1 || true)
+              fi
+              [ -z "$name" ] && name="$name_key"
+              [ -z "$desc" ] && desc="$desc_key"
             version=$(grep -Po 'MODULE\.version\s*=\s*[0-9]+(\.[0-9]{2})?' "$m" | sed -E 's/.*=\s*//' || true)
             [ -z "$version" ] && version="0.00"
             rawf=$(grep -Po 'MODULE\.Features\s*=\s*(\{[^}]*\}|"[^"]*")' "$m" | head -n1 | sed -E 's/^[^=]+=\s*//' || true)


### PR DESCRIPTION
## Summary
- Resolve module names and descriptions to their English language values when scraping metadata

## Testing
- `yamllint .github/workflows/ci.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_6899b671446083279bab54e07ed7e576