### PR TITLE
Add unique module identifiers

### DIFF
--- a/advert/module.lua
+++ b/advert/module.lua
@@ -1,5 +1,5 @@
 ﻿MODULE.name = "Advertisements"
-MODULE.uniqueID = "advert"
+MODULE.uniqueID = "public_advert"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.22

--- a/alcoholism/module.lua
+++ b/alcoholism/module.lua
@@ -1,5 +1,5 @@
 ﻿MODULE.name = "Alcoholism"
-MODULE.uniqueID = "alcoholism"
+MODULE.uniqueID = "public_alcoholism"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.24

--- a/autorestarter/module.lua
+++ b/autorestarter/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Auto Restarter"
+MODULE.uniqueID = "public_autorestarter"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.20

--- a/bodygrouper/module.lua
+++ b/bodygrouper/module.lua
@@ -1,5 +1,5 @@
 ﻿MODULE.name = "Body Group Editor"
-MODULE.uniqueID = "bodygrouper"
+MODULE.uniqueID = "public_bodygrouper"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.32

--- a/broadcasts/module.lua
+++ b/broadcasts/module.lua
@@ -1,5 +1,5 @@
 ﻿MODULE.name = "Broadcasts"
-MODULE.uniqueID = "broadcasts"
+MODULE.uniqueID = "public_broadcasts"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.28

--- a/captions/module.lua
+++ b/captions/module.lua
@@ -1,5 +1,5 @@
 ﻿MODULE.name = "Captions"
-MODULE.uniqueID = "captions"
+MODULE.uniqueID = "public_captions"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.23

--- a/cards/module.lua
+++ b/cards/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Cards"
+MODULE.uniqueID = "public_cards"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.18

--- a/chatmessages/module.lua
+++ b/chatmessages/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Chat Messages"
+MODULE.uniqueID = "public_chatmessages"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.20

--- a/cigs/module.lua
+++ b/cigs/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Cigarettes"
+MODULE.uniqueID = "public_cigs"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.22

--- a/cinematictext/module.lua
+++ b/cinematictext/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Cinematic Text"
+MODULE.uniqueID = "public_cinematictext"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.29

--- a/climb/module.lua
+++ b/climb/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Climbing"
+MODULE.uniqueID = "public_climb"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/communitycommands/module.lua
+++ b/communitycommands/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Community Commands"
+MODULE.uniqueID = "public_communitycommands"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.23

--- a/compass/module.lua
+++ b/compass/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Compass"
+MODULE.uniqueID = "public_compass"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.18

--- a/corpseid/module.lua
+++ b/corpseid/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Corpse ID"
+MODULE.uniqueID = "public_corpseid"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.25

--- a/cursor/module.lua
+++ b/cursor/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Cursor"
+MODULE.uniqueID = "public_cursor"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.18

--- a/cutscenes/module.lua
+++ b/cutscenes/module.lua
@@ -1,5 +1,6 @@
 ﻿local MODULE = MODULE
 MODULE.name = "Cutscenes"
+MODULE.uniqueID = "public_cutscenes"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.22

--- a/damagenumbers/module.lua
+++ b/damagenumbers/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Damage Numbers"
+MODULE.uniqueID = "public_damagenumbers"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.20

--- a/developmenthud/module.lua
+++ b/developmenthud/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Development HUD"
+MODULE.uniqueID = "public_developmenthud"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.26

--- a/developmentserver/module.lua
+++ b/developmentserver/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Development Server"
+MODULE.uniqueID = "public_developmentserver"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.16

--- a/discordrelay/module.lua
+++ b/discordrelay/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Discord Relay"
+MODULE.uniqueID = "public_discordrelay"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.17

--- a/donator/module.lua
+++ b/donator/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Donator"
+MODULE.uniqueID = "public_donator"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.31

--- a/doorkick/module.lua
+++ b/doorkick/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Door Kick"
+MODULE.uniqueID = "public_doorkick"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.20

--- a/enhanceddeath/module.lua
+++ b/enhanceddeath/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Enhanced Death"
+MODULE.uniqueID = "public_enhanceddeath"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.16

--- a/extendeddescriptions/module.lua
+++ b/extendeddescriptions/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Extended Descriptions"
+MODULE.uniqueID = "public_extendeddescriptions"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.28

--- a/firstpersoneffects/module.lua
+++ b/firstpersoneffects/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "First Person Effects"
+MODULE.uniqueID = "public_firstpersoneffects"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/flashlight/module.lua
+++ b/flashlight/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Flashlight"
+MODULE.uniqueID = "public_flashlight"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/freelook/module.lua
+++ b/freelook/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Free Look"
+MODULE.uniqueID = "public_freelook"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.20

--- a/gamemasterpoints/module.lua
+++ b/gamemasterpoints/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Gamemaster Points"
+MODULE.uniqueID = "public_gamemasterpoints"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.21

--- a/hud_extras/module.lua
+++ b/hud_extras/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "HUD Extras"
+MODULE.uniqueID = "public_hud_extras"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.25

--- a/instakill/module.lua
+++ b/instakill/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Instakill"
+MODULE.uniqueID = "public_instakill"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.21

--- a/joinleavemessages/module.lua
+++ b/joinleavemessages/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Join Leave Messages"
+MODULE.uniqueID = "public_joinleavemessages"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/loadmessages/module.lua
+++ b/loadmessages/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Load Messages"
+MODULE.uniqueID = "public_loadmessages"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.18

--- a/loyalism/module.lua
+++ b/loyalism/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Loyalism"
+MODULE.uniqueID = "public_loyalism"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.24

--- a/mapcleaner/module.lua
+++ b/mapcleaner/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Map Cleaner"
+MODULE.uniqueID = "public_mapcleaner"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.18

--- a/modelpay/module.lua
+++ b/modelpay/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Model Pay"
+MODULE.uniqueID = "public_modelpay"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/modeltweaker/module.lua
+++ b/modeltweaker/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Model Tweaker"
+MODULE.uniqueID = "public_modeltweaker"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.23

--- a/npcdrop/module.lua
+++ b/npcdrop/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "NPC Drop"
+MODULE.uniqueID = "public_npcdrop"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.18

--- a/npcspawner/module.lua
+++ b/npcspawner/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "NPC Spawner"
+MODULE.uniqueID = "public_npcspawner"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.24

--- a/permaremove/module.lua
+++ b/permaremove/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Perma Remove"
+MODULE.uniqueID = "public_permaremove"
 MODULE.author = "Boz [Base Code] & Samael [Rewrite]"
 MODULE.discord = "bozdev"
 MODULE.version = 1.23

--- a/radio/module.lua
+++ b/radio/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Radio"
+MODULE.uniqueID = "public_radio"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.25

--- a/raisedweapons/module.lua
+++ b/raisedweapons/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Raised Weapons"
+MODULE.uniqueID = "public_raisedweapons"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.21

--- a/realisticdamage/module.lua
+++ b/realisticdamage/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Realistic Damage"
+MODULE.uniqueID = "public_realisticdamage"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.18

--- a/realisticview/module.lua
+++ b/realisticview/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Realistic View"
+MODULE.uniqueID = "public_realisticview"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.21

--- a/rumour/module.lua
+++ b/rumour/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Anonymous Rumors"
+MODULE.uniqueID = "public_rumour"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/shootlock/module.lua
+++ b/shootlock/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Shoot Lock"
+MODULE.uniqueID = "public_shootlock"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.21

--- a/simple_lockpicking/module.lua
+++ b/simple_lockpicking/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Simple Lockpicking"
+MODULE.uniqueID = "public_simple_lockpicking"
 MODULE.author = "76561198312513285"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/slots/module.lua
+++ b/slots/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Slot Machine"
+MODULE.uniqueID = "public_slots"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/slowweapons/module.lua
+++ b/slowweapons/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Slow Weapons"
+MODULE.uniqueID = "public_slowweapons"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.19

--- a/stungun/module.lua
+++ b/stungun/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Stun Gun"
+MODULE.uniqueID = "public_stungun"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 101.23

--- a/tying/module.lua
+++ b/tying/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Tying"
+MODULE.uniqueID = "public_tying"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.29

--- a/utilities/module.lua
+++ b/utilities/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Code Utilities"
+MODULE.uniqueID = "public_utilities"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.25

--- a/viewbob/module.lua
+++ b/viewbob/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "View Bob"
+MODULE.uniqueID = "public_viewbob"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.21

--- a/vmanip/module.lua
+++ b/vmanip/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "View Manipulation"
+MODULE.uniqueID = "public_vmanip"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.22

--- a/warrants/module.lua
+++ b/warrants/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Warrant System"
+MODULE.uniqueID = "public_warrants"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.33

--- a/wartable/module.lua
+++ b/wartable/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "War Table"
+MODULE.uniqueID = "public_wartable"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.23

--- a/wordfilter/module.lua
+++ b/wordfilter/module.lua
@@ -1,4 +1,5 @@
 ﻿MODULE.name = "Word Filter"
+MODULE.uniqueID = "public_wordfilter"
 MODULE.author = "Samael"
 MODULE.discord = "@liliaplayer"
 MODULE.version = 1.24


### PR DESCRIPTION
## Summary
- assign `MODULE.uniqueID` to every module using the `public_<folder>` naming scheme

## Testing
- `node - <<'NODE'
const fs = require('fs');
const path = require('path');
let ok = true;
for (const dir of fs.readdirSync('.')) {
  const file = path.join(dir, 'module.lua');
  if (fs.existsSync(file)) {
    const content = fs.readFileSync(file, 'utf8').replace(/\uFEFF/g, '');
    const match = content.match(/MODULE\.uniqueID\s*=\s*"([^"]+)"/);
    if (!match || match[1] !== `public_${dir}`) {
      console.error('Mismatch for', dir, 'found', match && match[1]);
      ok = false;
    }
  }
}
if (ok) console.log('All modules have correct uniqueID');
NODE`
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b1d0be5a88327882232b8640a5667