### PR TITLE
Localize utilities time difference output

### DIFF
--- a/utilities/languages/english.lua
+++ b/utilities/languages/english.lua
@@ -3,5 +3,6 @@ LANGUAGE = {
     invalidDates = "Invalid dates",
     invalidTimeFormat = "Invalid time format. Expected 'HH:MM:SS - DD/MM/YYYY'.",
     invalidTimeValues = "Invalid time values.",
-    timeIsPast = "The specified time is in the past."
+    timeIsPast = "The specified time is in the past.",
+    timeDifferenceFormat = "%d years, %d months, %d days, %d hours, %d minutes, %d seconds"
 }

--- a/utilities/languages/french.lua
+++ b/utilities/languages/french.lua
@@ -5,5 +5,6 @@ LANGUAGE = {
     invalidTimeFormat = "Invalid time format. Expected 'HH:MM:SS - DD/MM/YYYY'.",
     invalidTimeValues = "Invalid time values.",
     timeIsPast = "The specified time is in the past.",
+    timeDifferenceFormat = "%d années, %d mois, %d jours, %d heures, %d minutes, %d secondes",
     invalidEntityPosition = "Invalid position for entity"
 }

--- a/utilities/languages/german.lua
+++ b/utilities/languages/german.lua
@@ -5,5 +5,6 @@ LANGUAGE = {
     invalidTimeFormat = "Invalid time format. Expected 'HH:MM:SS - DD/MM/YYYY'.",
     invalidTimeValues = "Invalid time values.",
     timeIsPast = "The specified time is in the past.",
+    timeDifferenceFormat = "%d Jahre, %d Monate, %d Tage, %d Stunden, %d Minuten, %d Sekunden",
     invalidEntityPosition = "Invalid position for entity"
 }

--- a/utilities/languages/italian.lua
+++ b/utilities/languages/italian.lua
@@ -5,5 +5,6 @@ LANGUAGE = {
     invalidTimeFormat = "Invalid time format. Expected 'HH:MM:SS - DD/MM/YYYY'.",
     invalidTimeValues = "Invalid time values.",
     timeIsPast = "The specified time is in the past.",
+    timeDifferenceFormat = "%d anni, %d mesi, %d giorni, %d ore, %d minuti, %d secondi",
     invalidEntityPosition = "Invalid position for entity"
 }

--- a/utilities/languages/portuguese.lua
+++ b/utilities/languages/portuguese.lua
@@ -5,5 +5,6 @@ LANGUAGE = {
     invalidTimeFormat = "Invalid time format. Expected 'HH:MM:SS - DD/MM/YYYY'.",
     invalidTimeValues = "Invalid time values.",
     timeIsPast = "The specified time is in the past.",
+    timeDifferenceFormat = "%d anos, %d meses, %d dias, %d horas, %d minutos, %d segundos",
     invalidEntityPosition = "Invalid position for entity"
 }

--- a/utilities/languages/russian.lua
+++ b/utilities/languages/russian.lua
@@ -5,5 +5,6 @@ LANGUAGE = {
     invalidTimeFormat = "Invalid time format. Expected 'HH:MM:SS - DD/MM/YYYY'.",
     invalidTimeValues = "Invalid time values.",
     timeIsPast = "The specified time is in the past.",
+    timeDifferenceFormat = "%d лет, %d месяцев, %d дней, %d часов, %d минут, %d секунд",
     invalidEntityPosition = "Invalid position for entity"
 }

--- a/utilities/languages/spanish.lua
+++ b/utilities/languages/spanish.lua
@@ -5,5 +5,6 @@ LANGUAGE = {
     invalidTimeFormat = "Invalid time format. Expected 'HH:MM:SS - DD/MM/YYYY'.",
     invalidTimeValues = "Invalid time values.",
     timeIsPast = "The specified time is in the past.",
+    timeDifferenceFormat = "%d años, %d meses, %d días, %d horas, %d minutos, %d segundos",
     invalidEntityPosition = "Invalid position for entity"
 }

--- a/utilities/libs/sh_utils.lua
+++ b/utilities/libs/sh_utils.lua
@@ -142,7 +142,7 @@ function lia.utilities.TimeUntil(str)
     local hdiff = math.floor(diff / 3600)
     diff = diff % 3600
     local mindiff = math.floor(diff / 60)
-    return string.format("%d years, %d months, %d days, %d hours, %d minutes, %d seconds", ydiff, mdiff, ddiff, hdiff, mindiff, diff % 60)
+    return L("timeDifferenceFormat", ydiff, mdiff, ddiff, hdiff, mindiff, diff % 60)
 end
 
 function lia.utilities.CurrentLocalTime()


### PR DESCRIPTION
## Summary
- use `L` for time difference string
- add `timeDifferenceFormat` translations to utilities languages

## Testing
- `luacheck utilities/libs/sh_utils.lua utilities/languages/english.lua utilities/languages/spanish.lua utilities/languages/french.lua utilities/languages/german.lua utilities/languages/italian.lua utilities/languages/portuguese.lua utilities/languages/russian.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bf2fe2de48327bfa5ca4ccc5f7d6a