### PR TITLE
Escape percent in rumour translations

### DIFF
--- a/rumour/languages/english.lua
+++ b/rumour/languages/english.lua
@@ -9,5 +9,5 @@ LANGUAGE = {
     rumorCooldownDesc = "Sets the cooldown time for rumors (in seconds).",
     gameplay = "Gameplay",
     rumourRevealChance = "Rumour Reveal Chance",
-    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%).",
+    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%%).",
 }

--- a/rumour/languages/french.lua
+++ b/rumour/languages/french.lua
@@ -9,5 +9,5 @@ LANGUAGE = {
     rumorCooldownDesc = "Sets the cooldown time for rumors (in seconds).",
     gameplay = "Gameplay",
     rumourRevealChance = "Rumour Reveal Chance",
-    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%).",
+    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%%).",
 }

--- a/rumour/languages/german.lua
+++ b/rumour/languages/german.lua
@@ -9,5 +9,5 @@ LANGUAGE = {
     rumorCooldownDesc = "Sets the cooldown time for rumors (in seconds).",
     gameplay = "Gameplay",
     rumourRevealChance = "Rumour Reveal Chance",
-    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%).",
+    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%%).",
 }

--- a/rumour/languages/italian.lua
+++ b/rumour/languages/italian.lua
@@ -9,5 +9,5 @@ LANGUAGE = {
     rumorCooldownDesc = "Sets the cooldown time for rumors (in seconds).",
     gameplay = "Gameplay",
     rumourRevealChance = "Rumour Reveal Chance",
-    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%).",
+    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%%).",
 }

--- a/rumour/languages/portuguese.lua
+++ b/rumour/languages/portuguese.lua
@@ -9,5 +9,5 @@ LANGUAGE = {
     rumorCooldownDesc = "Sets the cooldown time for rumors (in seconds).",
     gameplay = "Gameplay",
     rumourRevealChance = "Rumour Reveal Chance",
-    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%).",
+    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%%).",
 }

--- a/rumour/languages/russian.lua
+++ b/rumour/languages/russian.lua
@@ -9,5 +9,5 @@ LANGUAGE = {
     rumorCooldownDesc = "Sets the cooldown time for rumors (in seconds).",
     gameplay = "Gameplay",
     rumourRevealChance = "Rumour Reveal Chance",
-    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%).",
+    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%%).",
 }

--- a/rumour/languages/spanish.lua
+++ b/rumour/languages/spanish.lua
@@ -9,5 +9,5 @@ LANGUAGE = {
     rumorCooldownDesc = "Sets the cooldown time for rumors (in seconds).",
     gameplay = "Gameplay",
     rumourRevealChance = "Rumour Reveal Chance",
-    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%).",
+    rumourRevealChanceDesc = "The chance for a rumour to reveal the criminal's identity (default 2%%).",
 }


### PR DESCRIPTION
## Summary
- escape `%` in rumour reveal chance description across all language files to prevent string.format errors

## Testing
- `luac -p rumour/languages/*.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bf52f6ae483279e30651d9fcc0656