### PR TITLE
docs(cutscenes): clarify CutsceneStarted hook params

### DIFF
--- a/cutscenes/docs/hooks.md
+++ b/cutscenes/docs/hooks.md
@@ -12,9 +12,9 @@ Fired when a cutscene begins running. On the server it is called for every playe
 
 **Parameters**
 
-* `player` (`Player`|nil): Player who started viewing the cutscene (server only).
+* `player` (`Player`): Player who started viewing the cutscene. *(Server only)*
 
-* `id` (`string`): Identifier of the cutscene.
+* `id` (`string`): Identifier of the cutscene. On the client this is the sole parameter.
 
 **Realm**
 


### PR DESCRIPTION
## Summary
- clarify CutsceneStarted hook's arguments to reflect server/client usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf3417cc832784dd02e349d4c877