### PR TITLE
docs(cursor): fix hook examples

### DIFF
--- a/cursor/docs/hooks.md
+++ b/cursor/docs/hooks.md
@@ -53,7 +53,7 @@ Runs right after the cursor texture has been drawn.
 **Example**
 
 ```lua
-hook.Add("PostRenderCursor", "ResetColor", function()
+hook.Add("PostRenderCursor", "ResetColor", function(mat)
     surface.SetDrawColor(255, 255, 255)
 end)
 ```
@@ -82,7 +82,7 @@ Executed every frame before the hovered panel has its cursor style changed.
 
 ```lua
 hook.Add("PreCursorThink", "BlockCursor", function(panel)
-    if panel.NoCursor then return false end
+    if panel.NoCursor then return end
 end)
 ```
 


### PR DESCRIPTION
## Summary
- fix PostRenderCursor example to use its material argument
- remove PreCursorThink example's false return

## Testing
- `luacheck cursor` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf2f92f4832781d90407fcec4440