### PR TITLE
docs(viewbob): clarify view punch hooks

### DIFF
--- a/viewbob/docs/hooks.md
+++ b/viewbob/docs/hooks.md
@@ -94,13 +94,13 @@ end)
 
 **Returns**
 
-`nil`
+`nil` — `Return value is ignored.`
 
 **Example**
 
 ```lua
-hook.Add("PreViewPunch", "ClampPunch", function(client, x, y, z)
-    return math.Clamp(x, -5, 5), y, z
+hook.Add("PreViewPunch", "LogPunch", function(client, x, y, z)
+    print("Upcoming punch:", x, y, z)
 end)
 ```
 
@@ -128,7 +128,7 @@ end)
 
 **Returns**
 
-`nil`
+`nil` — `Return value is ignored.`
 
 **Example**
 


### PR DESCRIPTION
## Summary
- clarify that PreViewPunch and PostViewPunch ignore returned values
- revise PreViewPunch example to log upcoming punches instead of returning values

## Testing
- `luacheck viewbob` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf1da0b883278deff070913ceb8a