### PR TITLE
docs: align warrants docs with code

### DIFF
--- a/warrants/docs/hooks.md
+++ b/warrants/docs/hooks.md
@@ -29,7 +29,7 @@ Module-specific events raised by the Warrant System module.
 **Example**
 
 ```lua
-hook.Add("PreWarrantToggle", "LogAttempt", function(char, actor, warranted)
+hook.Add("PreWarrantToggle", "LogAttempt", function(char, warranter, warranted)
     print("Warrant change for " .. char:getName())
 end)
 ```
@@ -61,7 +61,7 @@ end)
 **Example**
 
 ```lua
-hook.Add("WarrantStatusChanged", "NotifyAdmins", function(char, actor, warranted)
+hook.Add("WarrantStatusChanged", "NotifyAdmins", function(char, warranter, warranted)
     if warranted then
         PrintMessage(HUD_PRINTTALK, char:getName() .. " is now warranted")
     end
@@ -95,7 +95,7 @@ end)
 **Example**
 
 ```lua
-hook.Add("PostWarrantToggle", "Cleanup", function(char, actor, warranted)
+hook.Add("PostWarrantToggle", "Cleanup", function(char, warranter, warranted)
     if not warranted then
         -- custom cleanup here
     end

--- a/warrants/docs/meta.md
+++ b/warrants/docs/meta.md
@@ -10,11 +10,13 @@ Extensions for managing a character's warrant status.
 
 Toggles the character's wanted status and notifies relevant players.
 
+**Parameters**
+
 | Name        | Type   | Description                     |
 
 | ----------- | ------ | ------------------------------- |
 
-| `warranter` | Player | Player initiating the toggle. |
+| `warranter` | Player | *(Optional)* Player initiating the toggle. |
 
 **Realm**
 
@@ -78,7 +80,7 @@ Returns whether the character currently has a warrant.
 
 **Realm**
 
-Shared
+Server
 
 **Returns**
 


### PR DESCRIPTION
## Summary
- document optional warranter parameter in `Character:ToggleWanted`
- mark `Character:IsWanted` as server-only
- use consistent `warranter` variable in hook examples

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf1555388327b6e8c31dc1ce7bc7