### PR TITLE
docs(vmanip): clarify PreVManipPickup usage

### DIFF
--- a/vmanip/docs/hooks.md
+++ b/vmanip/docs/hooks.md
@@ -27,10 +27,8 @@ Module-specific events raised by the Viewmodel Animations module.
 **Example**
 
 ```lua
-hook.Add("PreVManipPickup", "BlockCertainItems", function(client, item)
-    if item.uniqueID == "restricted" then
-        return false
-    end
+hook.Add("PreVManipPickup", "NotifyPickup", function(client, item)
+    print(client:Name() .. " is picking up " .. item.uniqueID)
 end)
 ```
 


### PR DESCRIPTION
## Summary
- clarify that `PreVManipPickup` can't block item pickup

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf19b79083279c4625cae239cac7