### PR TITLE
docs: clarify cigs puff count description

### DIFF
--- a/cigs/docs/hooks.md
+++ b/cigs/docs/hooks.md
@@ -78,7 +78,7 @@ Occurs when a player releases smoke after holding a cigarette.
 
 * `cigID` (`number`): Identifier of the cigarette item.
 
-* `puffs` (`number`): How many puffs were taken.
+* `puffs` (`number`): Total puffs taken so far.
 
 **Realm**
 


### PR DESCRIPTION
## Summary
- clarify that `PlayerPuffSmoke`'s `puffs` argument represents total inhalations so far

## Testing
- `luacheck cigs` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ddedf88c88327bbf115aee24425db