### PR TITLE
docs: clarify captions API

### DIFF
--- a/captions/docs/hooks.md
+++ b/captions/docs/hooks.md
@@ -78,11 +78,16 @@ end)
 
 **Parameters**
 
-* `clientOrText` (`Player|string`): `On the server this is the target player, on the client this is the caption text.`
+**Server**
 
-* `textOrDuration` (`string|number`): `On the server this is the caption text, on the client this is the duration.`
+* `client` (`Player`): `The player receiving the caption.`
+* `text` (`string`): `Caption text.`
+* `duration` (`number`): `How long the caption should display.`
 
-* `duration` (`number`, optional): `Duration when running server side.`
+**Client**
+
+* `text` (`string`): `Caption text.`
+* `duration` (`number`): `How long the caption should display.`
 
 **Realm**
 
@@ -110,7 +115,13 @@ end)
 
 **Parameters**
 
-* `client` (`Player`, optional): `The player whose caption ended when on the server.`
+**Server**
+
+* `client` (`Player`): `The player whose caption ended.`
+
+**Client**
+
+* *(None)*
 
 **Realm**
 

--- a/captions/docs/libraries.md
+++ b/captions/docs/libraries.md
@@ -22,7 +22,7 @@ The net strings `StartCaption` and `EndCaption` are registered automatically whe
 
 ---
 
-### lia.caption.start
+### lia.caption.start (Server)
 
 **Purpose**
 
@@ -57,7 +57,7 @@ lia.caption.start(ply, "Access Granted", 5)
 
 ---
 
-### lia.caption.finish
+### lia.caption.finish (Server)
 
 **Purpose**
 
@@ -88,7 +88,7 @@ lia.caption.finish(ply)
 
 ---
 
-### lia.caption.start
+### lia.caption.start (Client)
 
 **Purpose**
 
@@ -121,7 +121,7 @@ lia.caption.start("Mission Complete", 3)
 
 ---
 
-### lia.caption.finish
+### lia.caption.finish (Client)
 
 **Purpose**
 


### PR DESCRIPTION
## Summary
- clarify hook parameters for caption events
- document server and client caption helpers separately

## Testing
- `luacheck captions` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dded2ed988327bfc0ede3c5ec612d