### PR TITLE
docs: clarify broadcast menu open hooks

### DIFF
--- a/broadcasts/docs/hooks.md
+++ b/broadcasts/docs/hooks.md
@@ -136,7 +136,7 @@ end)
 
 **Purpose**
 
-`Fires when the class broadcast selection menu is presented.`
+`Runs before the class broadcast selection menu is presented.`
 
 **Parameters**
 
@@ -228,7 +228,7 @@ end)
 
 **Purpose**
 
-`Fires when the faction broadcast selection menu appears.`
+`Runs before the faction broadcast selection menu appears.`
 
 **Parameters**
 


### PR DESCRIPTION
## Summary
- clarify that `ClassBroadcastMenuOpened` and `FactionBroadcastMenuOpened` run before their menus appear

## Testing
- `luacheck broadcasts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddecd40d883278223a9f32dfeae39