### PR TITLE
autorestarter: clean up hook docs

### DIFF
--- a/autorestarter/docs/hooks.md
+++ b/autorestarter/docs/hooks.md
@@ -114,5 +114,3 @@ hook.Add("AutoRestartCountdown", "DisplayTimer", function(remaining)
 end)
 ```
 
----
-


### PR DESCRIPTION
## Summary
- remove stray trailing separator from Auto Restarter hook documentation

## Testing
- `luacheck autorestarter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddebe711883278925bea73dfce1c4