### PR TITLE
Clarify DevServerAuthorized hook behavior

### DIFF
--- a/developmentserver/docs/hooks.md
+++ b/developmentserver/docs/hooks.md
@@ -36,7 +36,7 @@ end)
 
 **Purpose**
 
-`Runs when an allowed developer joins the server while dev mode is active.`
+`Fires when a player passes the development server check (either dev mode is disabled or their SteamID64 is authorized).`
 
 **Parameters**
 


### PR DESCRIPTION
## Summary
- clarify DevServerAuthorized hook documentation to match actual authorization logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de2b39c0c83278f6b09313bfec263