### PR TITLE
fix enhanceddeath hooks doc module name

### DIFF
--- a/enhanceddeath/docs/hooks.md
+++ b/enhanceddeath/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-Module-specific events raised by the Hospital Respawn module.
+Module-specific events raised by the Enhanced Death module.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix hooks documentation to reference Enhanced Death module

## Testing
- `luac -p enhanceddeath/config.lua enhanceddeath/module.lua enhanceddeath/libraries/server.lua enhanceddeath/languages/*.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689de2c40e848327ac7a550bb580632b