### PR TITLE
Clarify join/leave hook docs

### DIFF
--- a/joinleavemessages/docs/hooks.md
+++ b/joinleavemessages/docs/hooks.md
@@ -8,7 +8,7 @@ Module-specific events raised by the Join Leave Messages module.
 
 **Purpose**
 
-`Called before a join or leave message is broadcast.`
+`Called before a join or leave message is broadcast. This hook cannot prevent the message from being sent.`
 
 **Parameters**
 
@@ -29,8 +29,8 @@ Module-specific events raised by the Join Leave Messages module.
 **Example**
 
 ```lua
-hook.Add("PreJoinLeaveMessageSent", "FilterMessages", function(ply, joined, msg)
-    if ply:IsBot() then return false end
+hook.Add("PreJoinLeaveMessageSent", "LogJoinLeave", function(ply, joined, msg)
+    print(ply:Nick(), joined and "joined" or "left")
 end)
 ```
 


### PR DESCRIPTION
## Summary
- document that PreJoinLeaveMessageSent cannot block messages
- replace example with simple join/leave logger

## Testing
- `luacheck joinleavemessages` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de2f38d8c8327a99e7c59ef85f2fc