### PR TITLE
docs(modelpay): add library docs and standardize hook returns

### DIFF
--- a/modelpay/docs/hooks.md
+++ b/modelpay/docs/hooks.md
@@ -22,7 +22,7 @@ Module-specific events raised by the Model Pay module.
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -54,7 +54,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -84,7 +84,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -114,7 +114,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -142,7 +142,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -172,7 +172,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -202,7 +202,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 

--- a/modelpay/docs/libraries.md
+++ b/modelpay/docs/libraries.md
@@ -1,0 +1,64 @@
+# Libraries
+
+Functions exposed by the Model Pay module.
+
+---
+
+### MODULE:GetSalaryAmount
+
+**Purpose**
+
+Calculates the wage assigned to a player based on their model.
+
+**Parameters**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `client` | Player | Player whose salary is being determined. |
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+`number` — `The pay amount for the player's model.`
+
+**Example**
+
+```lua
+local pay = MODULE:GetSalaryAmount(client)
+```
+
+---
+
+### MODULE:PlayerModelChanged
+
+**Purpose**
+
+Handles player model changes and triggers eligibility hooks.
+
+**Parameters**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `client` | Player | Player who changed model. |
+| `newModel` | string | Path of the new model. |
+
+**Realm**
+
+`Server`
+
+**Returns**
+
+`nil` — `This function does not return anything.`
+
+**Example**
+
+```lua
+-- Called automatically when a player's model updates
+MODULE:PlayerModelChanged(client, "models/player/barney.mdl")
+```
+
+---
+


### PR DESCRIPTION
## Summary
- document the Model Pay library with salary and model-change helpers
- clarify hook return values use `nil`

## Testing
- `lua -p module.lua libraries/server.lua languages/*.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689de305fb74832790b4c2863dc6e350