### PR TITLE
docs: fix HUD Extras hook example

### DIFF
--- a/hud_extras/docs/hooks.md
+++ b/hud_extras/docs/hooks.md
@@ -12,7 +12,7 @@ Module-specific events raised by the HUD Extras module.
 
 **Parameters**
 
-* *(None)*
+*None*
 
 **Realm**
 
@@ -26,7 +26,7 @@ Module-specific events raised by the HUD Extras module.
 
 ```lua
 hook.Add("RefreshFonts", "HUDExtrasFonts", function()
-    surface.CreateFont("HUDFont", {font = lia.config.get("HUDExtrasFont"), size = 24})
+    surface.CreateFont("HUDFont", {font = lia.config.get("FPSHudFont"), size = 24})
 end)
 ```
 


### PR DESCRIPTION
## Summary
- correct RefreshFonts hook example to use FPSHudFont config
- standardize parameter formatting to *None*

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de2eac67c8327bda3847ceadf74f7