### PR TITLE
docs: document AddTextField hook

### DIFF
--- a/radio/docs/hooks.md
+++ b/radio/docs/hooks.md
@@ -36,6 +36,40 @@ end)
 
 ---
 
+### `AddTextField`
+
+**Purpose**
+
+`Appends a read-only text field to a section of the radio information window.`
+
+**Parameters**
+
+* `section` (`string`): `Section title to attach the field under.`
+
+* `identifier` (`string`): `Unique ID for the field.`
+
+* `label` (`string`): `Displayed label for the field.`
+
+* `getter` (`function`): `Function returning the text to display.`
+
+**Realm**
+
+`Client`
+
+**Returns**
+
+`nil` — `No return value.`
+
+**Example**
+
+```lua
+hook.Add("AddTextField", "ShowRadioPower", function(section, id, label, getter)
+    print("Displaying", label, "in", section)
+end)
+```
+
+---
+
 
 ### `ShouldRadioBeep`
 


### PR DESCRIPTION
## Summary
- document AddTextField hook in radio module docs

## Testing
- `find radio -name '*.lua' -print0 | xargs -0 -n1 luac -p` *(fails: luac not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689de30fa0b48327a69ae9cf8c16d24d