### PR TITLE
docs: fix npcdrop hook docs

### DIFF
--- a/npcdrop/docs/hooks.md
+++ b/npcdrop/docs/hooks.md
@@ -20,7 +20,7 @@ Module-specific events raised by the NPC Drops module.
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -48,7 +48,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -76,7 +76,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -100,7 +100,7 @@ end)
 
 * `choice` (`number`): `Random number selected.`
 
-* `total` (`number`): `Total weight of all items.`
+* `totalWeight` (`number`): `Total weight of all items.`
 
 **Realm**
 
@@ -108,13 +108,13 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
 ```lua
-hook.Add("NPCDropRoll", "Debug", function(ent, choice, total)
-    print("Rolled", choice, "out of", total)
+hook.Add("NPCDropRoll", "Debug", function(ent, choice, totalWeight)
+    print("Rolled", choice, "out of", totalWeight)
 end)
 ```
 
@@ -138,7 +138,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 
@@ -166,7 +166,7 @@ end)
 
 **Returns**
 
-`void` — `None`
+`nil` — `This hook does not return anything.`
 
 **Example**
 


### PR DESCRIPTION
## Summary
- correct `NPCDropRoll` hook parameter to `totalWeight`
- standardize hook return descriptions to `nil`

## Testing
- `luacheck npcdrop` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689de3140a8c83278fb40c6255e17b30