### PR TITLE
docs: fix shootlock hook examples

### DIFF
--- a/shootlock/docs/hooks.md
+++ b/shootlock/docs/hooks.md
@@ -29,7 +29,7 @@ Module-specific events raised by the Shoot Locks module.
 **Example**
 
 ```lua
-hook.Add("LockShotAttempt", "AlertSecurity", function(client, door)
+hook.Add("LockShotAttempt", "AlertSecurity", function(client, door, dmgInfo)
     print(client:Name() .. " fired at " .. tostring(door))
 end)
 ```
@@ -154,7 +154,7 @@ end)
 **Example**
 
 ```lua
-hook.Add("LockShotFailed", "BreachFailed", function(client, door)
+hook.Add("LockShotFailed", "BreachFailed", function(client, door, dmgInfo)
     client:notify("The lock held strong.")
 end)
 ```


### PR DESCRIPTION
## Summary
- fix LockShotAttempt example to include dmgInfo parameter
- add missing dmgInfo parameter to LockShotFailed example

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de331a4c88327aa2ce58fdec26ddc