### PR TITLE
docs: clarify SlotMachineUse hook example

### DIFF
--- a/slots/docs/hooks.md
+++ b/slots/docs/hooks.md
@@ -29,7 +29,7 @@ Module-specific events raised by the Slot Machine module.
 ```lua
 hook.Add("SlotMachineUse", "CheckVIP", function(machine, client)
     if not client:isVIP() then
-        return false
+        print("Only VIPs can play.")
     end
 end)
 ```


### PR DESCRIPTION
## Summary
- clarify SlotMachineUse hook example to avoid implying return value is read

## Testing
- `luacheck slots` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de335c20c8327b1bf0406f4192754