### PR TITLE
Rename public_uniqueID to uniqueID and modules.json to version.json

### DIFF
--- a/generate_about_md.js
+++ b/generate_about_md.js
@@ -1,11 +1,11 @@
 const fs = require('fs')
 const path = require('path')
 
-let modulesPath = path.join(__dirname, 'modules.json')
-if (!fs.existsSync(modulesPath)) {
-  const alternativePath = path.join(__dirname, 'documentation', 'modules.json')
+let versionPath = path.join(__dirname, 'version.json')
+if (!fs.existsSync(versionPath)) {
+  const alternativePath = path.join(__dirname, 'documentation', 'version.json')
   if (fs.existsSync(alternativePath)) {
-    modulesPath = alternativePath
+    versionPath = alternativePath
   } else {
     process.exit(1)
   }
@@ -13,7 +13,7 @@ if (!fs.existsSync(modulesPath)) {
 
 let modules
 try {
-  modules = JSON.parse(fs.readFileSync(modulesPath, 'utf8'))
+  modules = JSON.parse(fs.readFileSync(versionPath, 'utf8'))
 } catch {
   process.exit(1)
 }
@@ -27,7 +27,7 @@ function toFolderName(name) {
 }
 
 for (const mod of modules) {
-  const id = mod.public_uniqueID || ''
+  const id = mod.uniqueID || ''
   if (!id) continue
 
   const folder = toFolderName(mod.name || id)

--- a/scrap_modules.js
+++ b/scrap_modules.js
@@ -40,7 +40,7 @@ for (const moduleInfo of modulesList) {
     description = '',
     features = [],
     download = '',
-    public_uniqueID = '',
+    uniqueID = '',
   } = moduleInfo
 
   const versionStr = toVersionString(version)
@@ -61,13 +61,13 @@ for (const moduleInfo of modulesList) {
     output += `</ul>\n\n`
   }
 
-  if (public_uniqueID) {
+  if (uniqueID) {
     const base = 'https://liliaframework.github.io/Modules/docs'
 
     output += `<p><strong>Libraries:</strong></p>\n`
-    output += `<p><a href="${base}/libraries/modules/${public_uniqueID}.html">Access Here</a></p>\n\n`
+    output += `<p><a href="${base}/libraries/modules/${uniqueID}.html">Access Here</a></p>\n\n`
     output += `<p><strong>Hooks:</strong></p>\n`
-    output += `<p><a href="${base}/hooks/modules/${public_uniqueID}.html">Access Here</a></p>\n\n`
+    output += `<p><a href="${base}/hooks/modules/${uniqueID}.html">Access Here</a></p>\n\n`
   }
 
   if (download) {


### PR DESCRIPTION
## Summary
- replace `public_uniqueID` usage with `uniqueID` in documentation generators
- switch module lookup from `modules.json` to `version.json`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e19e1c8fc832781ee6282fc1037f3