### PR TITLE
Move modules JSON to versioning docs directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,9 +281,9 @@ jobs:
           else
             rsync -a built-docs/ lilia/documentation/
           fi
-          mkdir -p lilia/documentation/docs
+          mkdir -p lilia/documentation/docs/versioning
           if [ -f lilia/documentation/modules.json ]; then
-            mv lilia/documentation/modules.json lilia/documentation/docs/modules.json
+            mv lilia/documentation/modules.json lilia/documentation/docs/versioning/modules.json
           fi
       - name: commit-push-docs
         shell: bash

--- a/generate_about_md.js
+++ b/generate_about_md.js
@@ -1,11 +1,11 @@
 const fs = require('fs')
 const path = require('path')
 
-let versionPath = path.join(__dirname, 'version.json')
-if (!fs.existsSync(versionPath)) {
-  const alternativePath = path.join(__dirname, 'documentation', 'version.json')
+let modulesPath = path.join(__dirname, 'modules.json')
+if (!fs.existsSync(modulesPath)) {
+  const alternativePath = path.join(__dirname, 'documentation', 'modules.json')
   if (fs.existsSync(alternativePath)) {
-    versionPath = alternativePath
+    modulesPath = alternativePath
   } else {
     process.exit(1)
   }
@@ -13,7 +13,7 @@ if (!fs.existsSync(versionPath)) {
 
 let modules
 try {
-  modules = JSON.parse(fs.readFileSync(versionPath, 'utf8'))
+  modules = JSON.parse(fs.readFileSync(modulesPath, 'utf8'))
 } catch {
   process.exit(1)
 }


### PR DESCRIPTION
## Summary
- adjust docs upload step to place modules.json in documentation/docs/versioning
- update about.md generator to read modules.json instead of version.json

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e27f2b6b48327aa864e2933dfd849