### PR TITLE
docs: add download buttons to module readmes

### DIFF
--- a/advert/README.md
+++ b/advert/README.md
@@ -15,3 +15,7 @@ Implements a paid /advert command for server-wide announcements. Messages are co
 - Adds price control via AdvertPrice configuration
 - Adds notifications when players lack funds
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/advert.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/alcoholism/README.md
+++ b/alcoholism/README.md
@@ -15,3 +15,7 @@ Adds drinkable alcohol that increases a player's intoxication level. High BAC bl
 - Adds configurable BAC settings like AlcoholTickTime
 - Adds multiple drink items with varying strength
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/alcoholism.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/autorestarter/README.md
+++ b/autorestarter/README.md
@@ -15,3 +15,7 @@ Schedules automatic server restarts at set intervals. Players see a countdown so
 - Adds automatic changelevel when the timer expires
 - Adds network messages to sync the restart countdown
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/autorestarter.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/bodygrouper/README.md
+++ b/bodygrouper/README.md
@@ -15,3 +15,7 @@ Spawns a bodygroup closet where players can edit their model's bodygroups. Admin
 - Adds an admin command to view another player's bodygroups
 - Adds a networked menu for editing bodygroups
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/bodygrouper.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/broadcasts/README.md
+++ b/broadcasts/README.md
@@ -14,3 +14,7 @@ Allows staff to broadcast messages to chosen factions or classes. Every broadcas
 - Adds CAMI privileges for broadcast access
 - Adds menus to select factions or classes
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/broadcasts.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/captions/README.md
+++ b/captions/README.md
@@ -15,3 +15,7 @@ Offers an API for timed on-screen captions suited for tutorials or story events.
 - Adds commands to send captions to players
 - Adds duration control for each caption
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/captions.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/cards/README.md
+++ b/cards/README.md
@@ -15,3 +15,7 @@ Adds a full deck of playing cards that can be shuffled and drawn. Card draws syn
 - Adds easy reshuffling of the deck
 - Adds hooks so other modules can use cards
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/cards.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/chatmessages/README.md
+++ b/chatmessages/README.md
@@ -15,3 +15,7 @@ Periodically posts automated advert messages in chat on a timer. Keeps players i
 - Adds rotating tips for new players
 - Adds toggle to disable adverts per user
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/chatmessages.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/cigs/README.md
+++ b/cigs/README.md
@@ -14,3 +14,7 @@ Adds smokable cigarette items with workshop models, puff effects while smoking, 
 - Adds cigarettes that are consumed over time
 - Adds ash particles that fade out
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/cigs.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/cinematictext/README.md
+++ b/cinematictext/README.md
@@ -15,3 +15,7 @@ Adds displays of cinematic splash text overlays, screen darkening with letterbox
 - Adds timed fades for dramatic effect
 - Adds customizable text fonts
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/cinematictext.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/climb/README.md
+++ b/climb/README.md
@@ -13,3 +13,7 @@ Adds the ability to climb ledges using movement keys, custom climbing animations
 - Adds custom climbing animations
 - Adds hooks for climb attempts
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/climb.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/communitycommands/README.md
+++ b/communitycommands/README.md
@@ -15,3 +15,7 @@ Adds chat commands to open community links, easy sharing of workshop and docs, c
 - Adds localization for command names
 - Adds the ability to add custom URLs
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/communitycommands.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/compass/README.md
+++ b/compass/README.md
@@ -15,3 +15,7 @@ Adds a rotating HUD compass display, spot markers showing enemy bearings, suppor
 - Adds pinging of points of interest
 - Adds compass size configuration
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/compass.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/corpseid/README.md
+++ b/corpseid/README.md
@@ -15,3 +15,7 @@ Adds the ability to identify corpses after IdentificationTime, use of CorpseMess
 - Adds configurable identification delays
 - Adds logs when corpses are identified
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/corpseid.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -15,3 +15,7 @@ Adds a toggleable custom cursor for the UI, a purely client-side implementation,
 - Adds a hotkey to quickly show or hide the cursor
 - Adds compatibility with other menu modules
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/cursor.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/cutscenes/README.md
+++ b/cutscenes/README.md
@@ -15,3 +15,7 @@ Adds a framework for simple cutscene playback, scenes defined through tables, sy
 - Adds commands to trigger cutscenes
 - Adds the ability for players to skip
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/cutscenes.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/damagenumbers/README.md
+++ b/damagenumbers/README.md
@@ -15,3 +15,7 @@ Adds floating combat text when hitting targets, different colors for damage type
 - Adds scaling text based on damage amount
 - Adds client option to disable numbers
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/damagenumbers.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/developmenthud/README.md
+++ b/developmenthud/README.md
@@ -15,3 +15,7 @@ Adds a staff-only development HUD, font customization via DevHudFont, a requirem
 - Adds real-time server performance metrics
 - Adds a toggle command to show or hide the HUD
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/developmenthud.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/developmentserver/README.md
+++ b/developmentserver/README.md
@@ -15,3 +15,7 @@ Adds a development server mode for testing, the ability to run special developme
 - Adds an environment flag for dev commands
 - Adds logging of executed dev actions
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/developmentserver.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/discordrelay/README.md
+++ b/discordrelay/README.md
@@ -15,3 +15,7 @@ Adds relaying of server logs to Discord, webhook integration for connectivity, f
 - Adds multiple webhook URLs per log type
 - Adds filtering to control which logs are sent
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/discordrelay.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/donator/README.md
+++ b/donator/README.md
@@ -14,3 +14,7 @@ Adds libraries to manage donor perks, tracking for donor ranks and perks, config
 - Adds configurable perks by tier
 - Adds commands to adjust character slots
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/donator.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/doorkick/README.md
+++ b/doorkick/README.md
@@ -14,3 +14,7 @@ Adds the ability to kick doors open with an animation, logging of door kick even
 - Adds a fun breach mechanic
 - Adds physics force to fling doors open
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/doorkick.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/enhanceddeath/README.md
+++ b/enhanceddeath/README.md
@@ -15,3 +15,7 @@ Adds respawning of players at hospitals, a medical recovery system, support for 
 - Adds configurable respawn delays
 - Adds integration with death logs
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/enhanceddeath.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/extendeddescriptions/README.md
+++ b/extendeddescriptions/README.md
@@ -15,3 +15,7 @@ Adds support for long item descriptions, localization for multiple languages, be
 - Adds automatic line wrapping
 - Adds fallback to short descriptions
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/extendeddescriptions.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/firstpersoneffects/README.md
+++ b/firstpersoneffects/README.md
@@ -14,3 +14,7 @@ Adds head bob and view sway, camera motion synced to actions, a realistic first-
 - Adds a realistic first-person feel
 - Adds adjustable intensity via config
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/firstpersoneffects.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/flashlight/README.md
+++ b/flashlight/README.md
@@ -14,3 +14,7 @@ Adds a serious flashlight with dynamic light, darkening of surroundings when tur
 - Adds adjustable brightness
 - Adds keybind toggle support
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/flashlight.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/freelook/README.md
+++ b/freelook/README.md
@@ -14,3 +14,7 @@ Adds the ability to look around without turning the body, a toggle key similar t
 - Adds movement direction preservation
 - Adds adjustable sensitivity while freelooking
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/freelook.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/gamemasterpoints/README.md
+++ b/gamemasterpoints/README.md
@@ -15,3 +15,7 @@ Adds teleport points for game masters, quick navigation across large maps, savin
 - Adds a command to list saved points
 - Adds sharing of points with other staff
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/gamemasterpoints.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/hud_extras/README.md
+++ b/hud_extras/README.md
@@ -15,3 +15,7 @@ Adds extra HUD elements like an FPS counter, fonts configurable with FPSHudFont,
 - Adds performance stats display
 - Adds toggles for individual HUD elements
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/hud_extras.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/instakill/README.md
+++ b/instakill/README.md
@@ -14,3 +14,7 @@ Adds instant kill on headshots, lethality configurable per weapon, extra tension
 - Adds extra tension to combat
 - Adds integration with damage numbers
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/instakill.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/joinleavemessages/README.md
+++ b/joinleavemessages/README.md
@@ -15,3 +15,7 @@ Adds announcements when players join, notifications on disconnect, improved comm
 - Adds relay of messages to Discord
 - Adds per-player toggle to hide messages
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/joinleavemessages.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/loadmessages/README.md
+++ b/loadmessages/README.md
@@ -15,3 +15,7 @@ Adds faction-based load messages, execution when players first load a character,
 - Adds color-coded formatting options
 - Adds per-faction enable toggles
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/loadmessages.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/loyalism/README.md
+++ b/loyalism/README.md
@@ -15,3 +15,7 @@ Adds a loyalty tier system for players, the /partytier command access, permissio
 - Adds automatic tier progression
 - Adds customizable rewards per tier
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/loyalism.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/mapcleaner/README.md
+++ b/mapcleaner/README.md
@@ -15,3 +15,7 @@ Adds periodic cleaning of map debris, a configurable interval, reduced server la
 - Adds a whitelist for protected entities
 - Adds manual cleanup commands
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/mapcleaner.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/modelpay/README.md
+++ b/modelpay/README.md
@@ -15,3 +15,7 @@ Adds payment to characters based on model, custom wage definitions, integration 
 - Adds config to exclude certain models
 - Adds logs of wages issued
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/modelpay.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/modeltweaker/README.md
+++ b/modeltweaker/README.md
@@ -15,3 +15,7 @@ Adds an entity to tweak prop models, adjustments for scale and rotation, easy UI
 - Adds saving of tweaked props between restarts
 - Adds undo support for recent tweaks
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/modeltweaker.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/npcdrop/README.md
+++ b/npcdrop/README.md
@@ -15,3 +15,7 @@ Adds NPCs that drop items on death, DropTable to define probabilities, encourage
 - Adds editable drop tables per NPC type
 - Adds weighted chances for rare items
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/npcdrop.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/npcspawner/README.md
+++ b/npcspawner/README.md
@@ -14,3 +14,7 @@ Adds automatic NPC spawns at points, the ability for admins to force spawns, log
 - Adds logging of spawn actions
 - Adds configuration for spawn intervals
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/npcspawner.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/permaremove/README.md
+++ b/permaremove/README.md
@@ -15,3 +15,7 @@ Adds ability to permanently delete map entities, logging for each removed entity
 - Adds confirmation prompts before removal
 - Adds restore list to undo mistakes
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/permaremove.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/radio/README.md
+++ b/radio/README.md
@@ -15,3 +15,7 @@ Adds a radio chat channel for players, font configuration via RadioFont, worksho
 - Adds frequency channels for groups
 - Adds handheld radio items
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/radio.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/raisedweapons/README.md
+++ b/raisedweapons/README.md
@@ -15,3 +15,7 @@ Adds auto-lowering of weapons when running, a raise delay set by WeaponRaiseSpee
 - Adds a toggle to keep weapons lowered
 - Adds compatibility with melee weapons
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/raisedweapons.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/realisticdamage/README.md
+++ b/realisticdamage/README.md
@@ -13,3 +13,7 @@ Adds damage scaling by body part, custom multipliers for realism, and adjustment
 - Adds custom multipliers for realism
 - Adds adjustments to player damage output
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/realisticdamage.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/realisticview/README.md
+++ b/realisticview/README.md
@@ -15,3 +15,7 @@ Adds a first-person view that shows the full body, immersive camera transitions,
 - Adds smooth leaning animations
 - Adds optional third-person override
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/realisticview.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/rumour/README.md
+++ b/rumour/README.md
@@ -15,3 +15,7 @@ Adds an anonymous rumour chat command, hiding of the sender's identity, encourag
 - Adds a cooldown to prevent spam
 - Adds admin logging of rumour messages
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/rumour.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/shootlock/README.md
+++ b/shootlock/README.md
@@ -14,3 +14,7 @@ Adds the ability to shoot door locks to open them, a quick breach alternative, a
 - Adds a loud action that may alert others
 - Adds chance-based lock destruction
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/shootlock.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/simple_lockpicking/README.md
+++ b/simple_lockpicking/README.md
@@ -15,3 +15,7 @@ Adds a simple lockpick tool for doors, logging of successful picks, brute-force 
 - Adds configurable pick time
 - Adds chance for tools to break
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/simple_lockpicking.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/slots/README.md
+++ b/slots/README.md
@@ -15,3 +15,7 @@ Adds a slot machine minigame, a workshop model for the machine, handling of payo
 - Adds customizable payout odds
 - Adds sound and animation effects
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/slots.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/slowweapons/README.md
+++ b/slowweapons/README.md
@@ -15,3 +15,7 @@ Adds slower movement while holding heavy weapons, speed penalties defined per we
 - Adds customizable weapon speed table
 - Adds automatic speed restore when switching
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/slowweapons.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/stungun/README.md
+++ b/stungun/README.md
@@ -15,3 +15,7 @@ Adds a taser weapon that immobilizes targets, StunTime and MaxDist as configurab
 - Adds networked stun animations
 - Adds logs when players are tased
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/stungun.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/tying/README.md
+++ b/tying/README.md
@@ -34,3 +34,7 @@ Adds searching of tied players' inventories, ability to confiscate contraband, s
 - Adds a configurable list of illegal items
 - Adds logging of confiscated belongings
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/tying.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/utilities/README.md
+++ b/utilities/README.md
@@ -15,3 +15,7 @@ Adds extra helper functions in lia.util, simplified utilities for common scripti
 - Adds utilities for networking data
 - Adds shared constants for modules
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/utilities.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/viewbob/README.md
+++ b/viewbob/README.md
@@ -14,3 +14,7 @@ Adds camera bobbing while moving, adjustable intensity, hooks to modify view pun
 - Adds hooks to modify view punch
 - Adds configuration for bobbing frequency
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/viewbob.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/vmanip/README.md
+++ b/vmanip/README.md
@@ -15,3 +15,7 @@ Adds VManip animation support, hand gestures for items, functionality within Lil
 - Adds API for custom gesture triggers
 - Adds fallback animations when VManip is missing
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/vmanip.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/warrants/README.md
+++ b/warrants/README.md
@@ -15,3 +15,7 @@ Adds ability to issue and remove player warrants, notifications displayed to pla
 - Adds CAMI privileges for warrant management
 - Adds timed expiration for warrants
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/warrants.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/wartable/README.md
+++ b/wartable/README.md
@@ -15,3 +15,7 @@ Adds an interactive 3D war table, the ability to plan operations on a map, a wor
 - Adds marker placement for strategies
 - Adds support for multiple map layouts
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/wartable.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>

--- a/wordfilter/README.md
+++ b/wordfilter/README.md
@@ -14,3 +14,7 @@ Adds chat word filtering, blocking of banned phrases, an easy-to-extend list, an
 - Adds an easy-to-extend list
 - Adds admin commands to modify the list
 
+
+
+
+<p align="center"><a href="https://github.com/LiliaFramework/Modules/raw/refs/heads/gh-pages/wordfilter.zip" style="display:inline-block;padding:12px 24px;font-size:1.5rem;font-weight:bold;text-decoration:none;color:#fff;background-color:var(--md-primary-fg-color,#007acc);border-radius:4px;">DOWNLOAD HERE</a></p>


### PR DESCRIPTION
## Summary
- add styled **Download Here** buttons linking to module zip files in each module README
- mirror format used in `generate_about_md.js`

## Testing
- `node generate_about_md.js` *(fails: modules.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a05f2cf7788327b7e6016abab0c380